### PR TITLE
Connection Pool + FireBird voorbereiding.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -17,6 +17,15 @@
       <profile default="true" name="Default" enabled="false">
         <processorPath useClasspath="true" />
       </profile>
+      <profile default="false" name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="true" />
+      </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="HikariCP" target="1.7" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$USER_HOME$/JAVA libraries/HikariCP" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/libraries/HikariCP_2_4_7_SNAPSHOT.xml
+++ b/.idea/libraries/HikariCP_2_4_7_SNAPSHOT.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="HikariCP-2.4.7-SNAPSHOT">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/zaxxer/HikariCP/2.4.7-SNAPSHOT/HikariCP-2.4.7-SNAPSHOT.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/c3p0_0_9_5_2.xml
+++ b/.idea/libraries/c3p0_0_9_5_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="c3p0-0.9.5.2">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/JAVA libraries/c3p0-0.9.5.2/lib/c3p0-0.9.5.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/jaybird_full_2_2_10.xml
+++ b/.idea/libraries/jaybird_full_2_2_10.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="jaybird-full-2.2.10">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/JAVA libraries/Jaybird-2/jaybird-full-2.2.10.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/slf4j_api_1_7_21.xml
+++ b/.idea/libraries/slf4j_api_1_7_21.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="slf4j-api-1.7.21">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/JAVA libraries/slf4j-1.7.21/slf4j-api-1.7.21.jar!/" />
+      <root url="jar://$USER_HOME$/JAVA libraries/slf4j-1.7.21/slf4j-simple-1.7.21.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -41,6 +41,9 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="Osmorc" url="file://$USER_HOME$/JAVA libraries/HikariCP" />
+  </component>
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" value="$USER_HOME$/Desktop/JavaDOC" />
     <option name="OPTION_SCOPE" value="protected" />
@@ -58,13 +61,6 @@
     <option name="LOCALE" />
     <option name="OPEN_IN_BROWSER" value="true" />
     <option name="OPTION_INCLUDE_LIBS" value="false" />
-  </component>
-  <component name="MavenImportPreferences">
-    <option name="generalSettings">
-      <MavenGeneralSettings>
-        <option name="mavenHome" value="Bundled (Maven 3)" />
-      </MavenGeneralSettings>
-    </option>
   </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />

--- a/Oplevering 2 -SQL-script.sql
+++ b/Oplevering 2 -SQL-script.sql
@@ -80,6 +80,8 @@ ENGINE = InnoDB;
 
 CREATE UNIQUE INDEX `uniekAdres` ON `RSVIERPROJECTDEEL2`.`ADRES` (`postcode` ASC, `huisnummer` ASC, `toevoeging` ASC);
 
+CREATE UNIQUE INDEX `adres_id_UNIQUE` ON `RSVIERPROJECTDEEL2`.`ADRES` (`adres_id` ASC);
+
 
 -- -----------------------------------------------------
 -- Table `RSVIERPROJECTDEEL2`.`KLANT_HEEFT_ADRES`

--- a/src/JUnit_tests/AdresDAOMySQLTest.java
+++ b/src/JUnit_tests/AdresDAOMySQLTest.java
@@ -1,134 +1,134 @@
-package JUnit_tests;
-
-import exceptions.RSVIERException;
-import interfaces.AdresDAO;
-import interfaces.KlantDAO;
-import model.Adres;
-import mysql.AdresDAOMySQL;
-import mysql.KlantDAOMySQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import static org.junit.Assert.*;
-
-/**
- * Created by Milan_Verheij on 09-06-16.
- *
- * TestClass om AdresDAOMySQL te Testen met JUnit
- */
-public class AdresDAOMySQLTest {
-    // Klant id is nodig om een adres te kunnen toevoegen
-    long klant_id_te_testen= 0;
-    KlantDAO klantDAO = new KlantDAOMySQL();
-    AdresDAO adresDAO = new AdresDAOMySQL();
-
-    String juisteTestStraatnaam = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // Max 26 karakters
-    String juisteTestPostcode = "9999AB"; // Max 6 karakters
-    String juisteTestToevoeging = "ABCDEF"; // max 6 karakters
-    int juisteTestHuisnummer = 9999; // meer is onmogelijk in Nederland
-    String juisteTestWoonplaats = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // Max 26 karakters
-    Adres testAdres;
-
-    @Before
-    public void setUp() throws Exception {
-        // Ik moet eerste een klant aanmaken voordat ik een adres kan toevoegen en deze kan testen.
-        // Derhalve eerste een nieuwe klant toevoegen en het klant_id achterhalen van deze klant
-        // door hierop te zoeken.
-        // TODO: Beter om direct bij die method ook maar de klant_id te returnen aangezien dat beste praktisch is.
-        klantDAO.nieuweKlant("JUnit1337", "Men1337eer");
-        klant_id_te_testen = klantDAO.getKlantOpKlant("JUnit1337", "Men1337eer").next().getKlant_id();
-        klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        klantDAO.schakelStatusKlant(klant_id_te_testen, 0);
-    }
-
-    @Test
-    public void TestUpdateAdresDAOnullAdres_geenException() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen, null);
-    }
-
-    @Test
-    public void TestUpdateAdresDAOBijNullAlleVeldenLeeg() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen, null);
-        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-        assertEquals("", testAdres.getStraatnaam());
-        assertEquals("", testAdres.getPostcode());
-        assertEquals(null, testAdres.getToevoeging());
-        assertEquals("", testAdres.getWoonplaats());
-        assertEquals(0, testAdres.getHuisnummer());
-    }
-
-    @Test
-    public void TestUpdateAdresDAOStraatNaamKlopt() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres(juisteTestStraatnaam, "", "", 0 , ""));
-        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-
-    }
-
-    @Test
-    public void TestUpdateAdresDAOPostcodeKlopt() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres("", juisteTestPostcode, "", 0 , ""));
-        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-
-        assertEquals(juisteTestPostcode, testAdres.getPostcode());
-    }
-
-    @Test
-    public void TestUpdateAdresDAOToevoegingKlopt() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres("", "", juisteTestToevoeging, 0 , ""));
-        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-
-        assertEquals(juisteTestToevoeging, testAdres.getToevoeging());
-    }
-
-    @Test
-    public void TestUpdateAdresDAOHuisnummerKlopt() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres("", "", "", juisteTestHuisnummer , ""));
-        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-
-        assertEquals(juisteTestHuisnummer, testAdres.getHuisnummer());
-    }
-
-    @Test
-    public void TestUpdateAdresDAOWoonplaatsKlopt() throws Exception {
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres("", "", "", 0 , juisteTestWoonplaats));
-        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
-
-        assertEquals(juisteTestWoonplaats, testAdres.getWoonplaats());
-    }
-
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
-    @Test
-    public void TestUpdateAdresDAOEenFoutieveInvoergRSVIERException() throws Exception {
-        // Een te lange postcode kan niet en ik verwacht dan ook dat er een RSVIERException wordt gegooid
-        // en wel een RSVierException
-        // Dit geld voor elke foutieve invoer, het gedrag zal hetzelfde zijn.
-        exception.expect(RSVIERException.class);
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres("", "TELANGEPOSTCODE", "", 0, ""));
-    }
-
-    @Test
-    public void TestUpdateAdresDAOConsistentGedragFoutieveInvoer() throws Exception {
-        // Test of dat ook bij een andere foutieve invoer eenzelfde fout wordt gegooid.
-        exception.expect(RSVIERException.class);
-        adresDAO.updateAdres(klant_id_te_testen,
-                new Adres("", "", "ABCDEFG", 0, ""));
-    }
-
-
-}
+//package JUnit_tests;
+//
+//import exceptions.RSVIERException;
+//import interfaces.AdresDAO;
+//import interfaces.KlantDAO;
+//import model.Adres;
+//import mysql.AdresDAOMySQL;
+//import mysql.KlantDAOMySQL;
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.junit.rules.ExpectedException;
+//
+//import static org.junit.Assert.*;
+//
+///**
+// * Created by Milan_Verheij on 09-06-16.
+// *
+// * TestClass om AdresDAOMySQL te Testen met JUnit
+// */
+//public class AdresDAOMySQLTest {
+//    // Klant id is nodig om een adres te kunnen toevoegen
+//    long klant_id_te_testen= 0;
+//    KlantDAO klantDAO = new KlantDAOMySQL();
+//    AdresDAO adresDAO = new AdresDAOMySQL();
+//
+//    String juisteTestStraatnaam = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // Max 26 karakters
+//    String juisteTestPostcode = "9999AB"; // Max 6 karakters
+//    String juisteTestToevoeging = "ABCDEF"; // max 6 karakters
+//    int juisteTestHuisnummer = 9999; // meer is onmogelijk in Nederland
+//    String juisteTestWoonplaats = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // Max 26 karakters
+//    Adres testAdres;
+//
+//    @Before
+//    public void setUp() throws Exception {
+//        // Ik moet eerste een klant aanmaken voordat ik een adres kan toevoegen en deze kan testen.
+//        // Derhalve eerste een nieuwe klant toevoegen en het klant_id achterhalen van deze klant
+//        // door hierop te zoeken.
+//        // TODO: Beter om direct bij die method ook maar de klant_id te returnen aangezien dat beste praktisch is.
+//        klantDAO.nieuweKlant("JUnit1337", "Men1337eer");
+//        klant_id_te_testen = klantDAO.getKlantOpKlant("JUnit1337", "Men1337eer").next().getKlant_id();
+//        klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//    }
+//
+//    @After
+//    public void tearDown() throws Exception {
+//        klantDAO.schakelStatusKlant(klant_id_te_testen, 0);
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOnullAdres_geenException() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen, null);
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOBijNullAlleVeldenLeeg() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen, null);
+//        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//        assertEquals("", testAdres.getStraatnaam());
+//        assertEquals("", testAdres.getPostcode());
+//        assertEquals(null, testAdres.getToevoeging());
+//        assertEquals("", testAdres.getWoonplaats());
+//        assertEquals(0, testAdres.getHuisnummer());
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOStraatNaamKlopt() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres(juisteTestStraatnaam, "", "", 0 , ""));
+//        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOPostcodeKlopt() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres("", juisteTestPostcode, "", 0 , ""));
+//        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//
+//        assertEquals(juisteTestPostcode, testAdres.getPostcode());
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOToevoegingKlopt() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres("", "", juisteTestToevoeging, 0 , ""));
+//        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//
+//        assertEquals(juisteTestToevoeging, testAdres.getToevoeging());
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOHuisnummerKlopt() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres("", "", "", juisteTestHuisnummer , ""));
+//        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//
+//        assertEquals(juisteTestHuisnummer, testAdres.getHuisnummer());
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOWoonplaatsKlopt() throws Exception {
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres("", "", "", 0 , juisteTestWoonplaats));
+//        testAdres = klantDAO.getKlantOpKlant(klant_id_te_testen).next().getAdresGegevens();
+//
+//        assertEquals(juisteTestWoonplaats, testAdres.getWoonplaats());
+//    }
+//
+//
+//    @Rule
+//    public final ExpectedException exception = ExpectedException.none();
+//
+//    @Test
+//    public void TestUpdateAdresDAOEenFoutieveInvoergRSVIERException() throws Exception {
+//        // Een te lange postcode kan niet en ik verwacht dan ook dat er een RSVIERException wordt gegooid
+//        // en wel een RSVierException
+//        // Dit geld voor elke foutieve invoer, het gedrag zal hetzelfde zijn.
+//        exception.expect(RSVIERException.class);
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres("", "TELANGEPOSTCODE", "", 0, ""));
+//    }
+//
+//    @Test
+//    public void TestUpdateAdresDAOConsistentGedragFoutieveInvoer() throws Exception {
+//        // Test of dat ook bij een andere foutieve invoer eenzelfde fout wordt gegooid.
+//        exception.expect(RSVIERException.class);
+//        adresDAO.updateAdres(klant_id_te_testen,
+//                new Adres("", "", "ABCDEFG", 0, ""));
+//    }
+//
+//
+//}

--- a/src/JUnit_tests/KlantDAOMySQLTest.java
+++ b/src/JUnit_tests/KlantDAOMySQLTest.java
@@ -1,616 +1,616 @@
-
-package JUnit_tests;
-
-import model.Adres;
-import model.Artikel;
-import model.Bestelling;
-import model.Klant;
-import mysql.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.ListIterator;
-
-import static org.junit.Assert.*;
-
-/**
- * Created by Milan_Verheij on 10-06-16.
- *
- * J-Unit testClass van KlantDAOMySQL
- *
- * Het betreffen hoofdzakelijk basis CRUD-methoden.
- *
- * Bijzonderheden zijn dat de get-methoden ListIterators van LinkedLists teruggeven, het Klant-specifieke deel
- * is opgenomen in een specifieke methode om een ResultSet naar een ArrayList van Klanten te zetten. De ResultSet
- * naar ArrayList methode wordt impliciet getest in de meeste methoden omdat bijna elke methode hiervan afhankelijk
- * is.
- *
- * Derhalve wordt er niet getest of de getmethoden op een juiste manier een ArrayList naar een Iterator zetten
- * omdat dit een standaard librarymethode is. ArrayList.listIterator. Als er een List-Iterator terugkomt is
- * de validiteit hiervan afhankelijk van eerdergenoemde methode en de uitgevoerde query.
- *
- */
-public class KlantDAOMySQLTest {
-    private KlantDAOMySQL klantDAO;
-    private BestellingDAOMySQL bestellingDAO;
-    private long nieuweKlantID;
-    private Klant tijdelijkeKlant;
-    private boolean nieuweKlantAangemaakt = false;
-    private final String VOORNAAM = "TestKlantVoornaam4101AR1225"; // Uniek ID  TODO: Random generator kan nog (nice to have)
-    private final String ACHTERNAAM = "TestKlantAchternaam4101AR1225"; // Uniek ID TODO: Random generator kan nog (nice to have)
-    private final String TUSSENVOEGSEL = "TUSS";
-    private final String EMAIL = "TestEmail@EmailLand.rsvier";
-    private final String STRAATNAAM = "TestStraatnaam9548";
-    private final String POSTCODE = "9548ZZ" ;
-    private final String TOEVOEGING = "ABC";
-    private final int HUISNUMMER = 9548;
-    private final String WOONPLAATS = "TestWoonplaats9548";
-    private Connection connection;
-    private PreparedStatement statement;
-    private ResultSet rs;
-
-    @Before
-    public void setUp() throws Exception {
-        klantDAO = new KlantDAOMySQL();
-        bestellingDAO = new BestellingDAOMySQL();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        // Vangnet
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
-        MySQLHelper.close(connection, statement, rs);
-
-        AdresDAOMySQL.klantWordtGetest = false; // Mocht er iets fout zijn gegaan in de tests..
-    }
-
-    // De nieuwe klant-methoden zijn helaas afhankelijk van de get-methoden om te kunnen vaststellen
-    // dat de DATA inderdaad juiste in de MYSQL-database is opgenomen.
-    // Tijdens de nieuwe klant methoden wordt ook direct getest of er wel een ID wordt aangemaakt en teruggeven.
-    // Het is niet zinvol dit los te testen.
-
-    @Test
-    public void nieuweKlantVoorAchternaamAdresNullIsLeeg() throws Exception {
-
-        // De nieuwe klant-methode met voor, achternaam en Adres gebruikt de nieuweKlant methode met alle
-        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
-        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
-        //
-        // Als er geen adresgegevens worden meegegeven (null) wordt er standaard een leeg
-        // Adres aangemaakt omdat er null wordt meegegeven naar de AdresDAO. Aldaar wordt als er null
-        // wordt geconstateerd een leeg adres gemaakt (dit valt buiten de scope van deze test).
-        //
-        // Deze methode test niet of dat de juiste gegevens naar de database worden verstuurd, dat doet
-        // de AdresDAOMySQLTest. Er wordt enkel gekeken of de juiste gegevens zijn doorgegeven aan AdresDAO (null)
-        // Dit kan doordat AdresDAOMySQL test of dat haar testwaarde op true staat en als dit het geval is
-        // wordt het adres tijdelijk opgeslagen.
-
-        nieuweKlantAangemaakt = true;
-        AdresDAOMySQL.klantWordtGetest = true; // Testconditie in AdresDAOMySQL goed zetten.
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, null);
-
-        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
-
-        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
-        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
-        assertTrue((AdresDAOMySQL.aangeroepenAdresInTest == null));
-
-
-        AdresDAOMySQL.klantWordtGetest = false;
-        tijdelijkeKlant = null;
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void nieuweKlantAdresMethodeJuistAangesproken() throws Exception {
-
-        // De nieuwe klant-methode met voor, achternaam en Adres gebruikt de nieuweKlant methode met alle
-        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
-        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
-        //
-        // Als er geen adresgegevens worden meegegeven (null) wordt er standaard een leeg
-        // Adres aangemaakt. Het aanmaken (of eigenlijk updaten o.b.v. klantID wordt afzonderlijk getest
-        //
-        // Deze methode test niet of dat de juiste gegegevens worden geschreven naar de Database. Het kan echter
-        // wel voorkomen dat als deze methode en fout geeft omdat er een fout is tijdens het schrijven naar de Database
-        // dat de test faalt.
-        //
-        // Het test verder enkel of dat de AdresDAO met de juiste gegevens is aangesproken.
-        //
-        // Dit is het geval als het testAdres-object (static) in de AdresDAO op de juiste gegevens staan.
-        // Er wordt in AdresDAO gekeken of er toevallig getest wordt, als ja dan wordt het test adres tijdelijk
-        // opgeslagen in AdresDAOMySQL.aangeroepenAdresInTest.
-
-        nieuweKlantAangemaakt = true;
-        AdresDAOMySQL.klantWordtGetest = true; // Testconditie in AdresDAOMySQL goed zetten.
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM,
-                new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS));
-
-        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
-
-        assertEquals(STRAATNAAM, AdresDAOMySQL.aangeroepenAdresInTest.getStraatnaam());
-        assertEquals(POSTCODE, AdresDAOMySQL.aangeroepenAdresInTest.getPostcode());
-        assertEquals(TOEVOEGING, AdresDAOMySQL.aangeroepenAdresInTest.getToevoeging());
-        assertEquals(HUISNUMMER, AdresDAOMySQL.aangeroepenAdresInTest.getHuisnummer());
-        assertEquals(WOONPLAATS, AdresDAOMySQL.aangeroepenAdresInTest.getWoonplaats());
-
-        AdresDAOMySQL.aangeroepenAdresInTest = null; // Resetten TestAdres
-        AdresDAOMySQL.klantWordtGetest = false;
-        tijdelijkeKlant = null;
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void nieuweKlantVoorAchternaam() throws Exception {
-        // De nieuwe klant-methode met voor- en achternaam gebruikt de nieuweKlant methode met alle
-        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
-        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
-        // TODO: IVM koppeling tussen methoden, allicht een Klant laten returnen en die checken?
-
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM);
-
-        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
-
-        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
-        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
-
-        tijdelijkeKlant = null; // TODO: OVeral fixen met wat het wel meot zijn
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void nieuweKlant() throws Exception {
-        // In deze methode wordt getest of dat alle gegevens juist naar de database worden weggeschreven
-        // als er zowel een Adres als Bestelling wordt meegegeven.
-        //
-        // Er wordt niet getest of de juiste Adres en / of Bestelgegevens worden meegegeven naar de Adres
-        // en / of BestelDAO. Dat wordt in de hieropvolgende tests getest.
-
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0,
-                null, null);
-
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
-
-        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
-        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
-        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
-        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
-
-        tijdelijkeKlant = null;
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void nieuweKlantEnBestelling() throws Exception {
-        // TODO: Overleg met Albert ivm boolean en testBestelObject
-        // De nieuwe klant-methode met voor, achternaam en Beslling gebruikt de nieuweKlant methode met alle
-        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
-        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
-        //
-        // Als er geen Bestelgegevens worden meegegeven (null) wordt er standaard een lege
-        // Bestelling aangemaakt. Het aanmaken (of eigenlijk updaten o.b.v. klantID wordt afzonderlijk getest
-        //
-        // Deze methode test niet of dat de juiste gegegevens worden geschreven naar de Database. Het kan echter
-        // wel voorkomen dat als deze methode en fout geeft omdat er een fout is tijdens het schrijven naar de Database
-        // dat de test faalt.
-        //
-        // Het test verder enkel of dat de BestellingDAO met de juiste gegevens is aangesproken.
-        //
-        // Dit is het geval als het testAdres-object (static) in de BestellingDAO op de juiste gegevens staan.
-        // Er wordt in Bestelling gekeken of er toevallig getest wordt, als ja dan wordt het test adres tijdelijk
-        // opgeslagen in BestellingDAOMySQL.aangeroepenAdresInTest.
-
-        nieuweKlantAangemaakt = true;
-        BestellingDAOMySQL.bestellingWordGetest = true; // Testconditie in BestellingDAOMySQL goed zetten.
-        Artikel a1 = new Artikel(333, "Mecronomicon", 3.33);
-        Artikel a2 = new Artikel(321, "Woynich Manuscript", 3.21);
-        Artikel a3 = new Artikel(888, "Nunich Manual of Demonic Magic", 8.88);
-
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null,
-                                new Bestelling(0, a1, a2, a3)); // ID wordt in de nieuweKlant methode op het juiste ID geze,
-
-        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
-
-        assertEquals(nieuweKlantID, BestellingDAOMySQL.aangeroepenBestellingInTest.getKlant_id());
-        LinkedHashMap<Artikel, Integer> artikelLijst = BestellingDAOMySQL.aangeroepenBestellingInTest.getArtikelLijst();
-
-        // In de bestelling moeten de volgende artikelen 1 x aanwezig zijn
-        // Er mogen niet meer dan drie artikelen aanwezig zijn.
-        assertTrue(artikelLijst.size() == 3);
-        assertEquals(1, (long)artikelLijst.get(a1));
-        assertEquals(1, (long)artikelLijst.get(a2));
-        assertEquals(1, (long)artikelLijst.get(a3));
-
-        // Alle waarden weer naar default
-        BestellingDAOMySQL.bestellingWordGetest = false;
-        BestellingDAOMySQL.aangeroepenBestellingInTest = new Bestelling(1,
-                new Artikel(666, "Necronomicon", 6.66),
-                new Artikel(123, "Voynich Manuscript", 1.23),
-                new Artikel(999, "Munich Manual of Demonic Magic", 9.99));
-        tijdelijkeKlant = null;
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void getAlleKlanten() throws Exception {
-        // Deze test controleert of daadwerkelijk alle klanten worden opgevraagd en zijn gegeven.
-        // Er wordt een query uitgevoerd om te peilen hoeveel klanten er zijn waarna deze wordt vergeleken
-        // met de grootte van de lijst.
-
-        connection = MySQLConnectieLeverancier.getConnection();
-        String query = "SELECT COUNT(*) FROM KLANT";
-        statement = connection.prepareStatement(query);
-        rs = statement.executeQuery();
-        int aantalKlantenInDB = 0;
-        int aantalKlantenInList = 0;
-
-        while (rs.next())
-            aantalKlantenInDB = rs.getInt(1);
-
-        ListIterator<Klant> klantenIterator = klantDAO.getAlleKlanten();
-        while (klantenIterator.hasNext()) {
-            klantenIterator.next();
-            aantalKlantenInList++;
-        }
-
-        assertEquals(aantalKlantenInDB, aantalKlantenInList);
-
-        MySQLHelper.close(connection, statement, rs);
-    }
-
-    @Test
-    public void getKlantOpKlant() throws Exception {
-        // Deze methode test of dat de juiste klant wordt gevonden op basis van klantID
-
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
-
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next();
-
-        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
-        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
-        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
-        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
-
-        tijdelijkeKlant = null;
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void getKlantOpKlantVoornaam() throws Exception {
-        // Deze methode test of dat de juiste klant wordt gevonden op basis van voornaam
-        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
-        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
-        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
-        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
-
-        nieuweKlantAangemaakt = true;
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL + "2", EMAIL + "2",0, null, null);
-
-        ListIterator<Klant> klantIterator = klantDAO.getKlantOpKlant(VOORNAAM);
-        ArrayList<Klant> klantenLijst = new ArrayList<>();
-        while (klantIterator.hasNext()) {
-            klantenLijst.add(klantIterator.next());
-        }
-
-        assertEquals(VOORNAAM, klantenLijst.get(0).getVoornaam());
-        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
-        assertEquals(TUSSENVOEGSEL, klantenLijst.get(0).getTussenvoegsel());
-        assertEquals(EMAIL, klantenLijst.get(0).getEmail());
-
-        assertEquals(VOORNAAM, klantenLijst.get(1).getVoornaam());
-        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
-        assertEquals(TUSSENVOEGSEL + "2", klantenLijst.get(1).getTussenvoegsel());
-        assertEquals(EMAIL + "2", klantenLijst.get(1).getEmail());
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
-    }
-
-    @Test
-    public void getKlantOpKlantVoornaamAchternaam() throws Exception {
-        // Deze methode test of dat de juiste klant wordt gevonden op basis van voornaam en achternaam
-        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
-        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
-        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
-        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
-
-        nieuweKlantAangemaakt = true;
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL,0, null, null);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL + "2", EMAIL + "2", 0, null, null);
-
-        ListIterator<Klant> klantIterator = klantDAO.getKlantOpKlant(VOORNAAM);
-        ArrayList<Klant> klantenLijst = new ArrayList<>();
-        while (klantIterator.hasNext()) {
-            klantenLijst.add(klantIterator.next());
-        }
-
-        assertEquals(VOORNAAM, klantenLijst.get(0).getVoornaam());
-        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
-        assertEquals(TUSSENVOEGSEL, klantenLijst.get(0).getTussenvoegsel());
-        assertEquals(EMAIL, klantenLijst.get(0).getEmail());
-
-        assertEquals(VOORNAAM, klantenLijst.get(1).getVoornaam());
-        assertEquals(ACHTERNAAM, klantenLijst.get(1).getAchternaam());
-        assertEquals(TUSSENVOEGSEL + "2", klantenLijst.get(1).getTussenvoegsel());
-        assertEquals(EMAIL + "2", klantenLijst.get(1).getEmail());
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-    }
-
-    @Test
-    public void getKlantOpVolledigAdres() throws Exception {
-        // Deze methode test of dat de juiste klant wordt gevonden op basis van de volledige adresdegevens
-        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
-        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
-        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
-        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
-
-        nieuweKlantAangemaakt = true;
-        Adres tijdelijkAdres = new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
-
-        ListIterator<Klant> klantIterator = klantDAO.getKlantOpAdres(tijdelijkAdres);
-        ArrayList<Klant> klantenLijst = new ArrayList<>();
-        while (klantIterator.hasNext()) {
-            klantenLijst.add(klantIterator.next());
-        }
-
-        // Check op klant 1 gevonden
-        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
-
-        // Check of klant twee ook werd gevonden
-        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
-    }
-
-    @Test
-    public void getKlantOpAdresStraatnaam() throws Exception {
-        // Deze methode test of dat de juiste klant wordt gevonden op basis van de straatnaam
-        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
-        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
-        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
-        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
-
-        nieuweKlantAangemaakt = true;
-        Adres tijdelijkAdres = new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
-
-        ListIterator<Klant> klantIterator = klantDAO.getKlantOpAdres(STRAATNAAM);
-        ArrayList<Klant> klantenLijst = new ArrayList<>();
-        while (klantIterator.hasNext()) {
-            klantenLijst.add(klantIterator.next());
-        }
-
-        // Check op klant 1 gevonden
-        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
-
-        // Check of klant twee ook werd gevonden
-        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
-        tijdelijkeKlant = null;
-    }
-
-    @Test
-    public void getKlantOpAdresPostcodeHuisNR() throws Exception {
-        // Deze methode test of dat de juiste klant wordt gevonden op basis van de postcode en het huisnummer
-        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
-        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
-        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
-        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
-
-        nieuweKlantAangemaakt = true;
-        Adres tijdelijkAdres = new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
-        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
-
-        ListIterator<Klant> klantIterator = klantDAO.getKlantOpAdres(POSTCODE, HUISNUMMER);
-        ArrayList<Klant> klantenLijst = new ArrayList<>();
-        while (klantIterator.hasNext()) {
-            klantenLijst.add(klantIterator.next());
-        }
-
-        // Check op klant 1 gevonden
-        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
-
-        // Check of klant twee ook werd gevonden
-        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
-        tijdelijkeKlant = null;
-    }
-
-    @Test
-    public void getKlantOpBestelling() throws Exception {
-        // Deze methode checkt of dat de juiste klant worden opgehaald op basis van
-        // het opgegeven Bestel_ID
-
-        // Er wordt een nieuwe klant gemaakt met een bestelling waarna deze wordt verwijderd.
-        BestellingDAOMySQL.bestellingWordGetest = true;
-
-        // Nieuwe klant aanmaken en klantID achterhalen, wordt altijd in teardown weer verwijderd
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
-
-        // Aan de hand van klantID een bestelling toevoegen aan de klant. Is getest in test hierboven.
-        long nieuweBestellingID = bestellingDAO.nieuweBestelling(nieuweKlantID,
-                new Artikel(333, "Mecronomicon", 3.33),
-                new Artikel(321, "Woynich Manuscript", 3.21),
-                new Artikel(888, "Nunich Manual of Demonic Magic", 8.88));
-
-        tijdelijkeKlant = klantDAO.getKlantOpBestelling(nieuweBestellingID).next();
-
-        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
-        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
-        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
-        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
-
-        // Alle waarden weer resetten naar default
-        tijdelijkeKlant = null;
-        BestellingDAOMySQL.bestellingWordGetest = false;
-        BestellingDAOMySQL.aangeroepenBestellingInTest = new Bestelling(1,
-                new Artikel(666, "Necronomicon", 6.66),
-                new Artikel(123, "Voynich Manuscript", 1.23),
-                new Artikel(999, "Munich Manual of Demonic Magic", 9.99));
-
-        nieuweKlantID = -1;
-    }
-
-    @Test
-    public void updateKlantGegeven() throws Exception {
-        // Deze methode test of de juiste klantGegevens worden geUpdate als een klantID wordt meegegeven
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant("", "", "", "", 0, null, null); // Leeg
-
-        klantDAO.updateKlant(nieuweKlantID, VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL);
-
-        // Vraag klant op en controleer de inhoud
-        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next();
-        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
-        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
-        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
-        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
-
-        tijdelijkeKlant = null;
-    }
-
-    @Test
-    public void updateKlantJuisteAdresGegevensMeegegeven() throws Exception {
-        // Deze methode test niet of dat de juiste gegevens in de database worden geschreven, dat wordt
-        // in de methode hierboven gedaan. Die methode wordt ook simpelweg aangeroepen in deze methode.
-        // Deze methode test of de juiste klantGegevens worden geUpdate als een klantID wordt meegegeven
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant("", "", "", "", 0, null, null); // Leeg
-
-        AdresDAOMySQL.klantWordtGetest = true;
-//        klantDAO.updateKlant(nieuweKlantID, VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL,
+//
+//package JUnit_tests;
+//
+//import model.Adres;
+//import model.Artikel;
+//import model.Bestelling;
+//import model.Klant;
+//import mysql.*;
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.Test;
+//
+//import java.sql.Connection;
+//import java.sql.PreparedStatement;
+//import java.sql.ResultSet;
+//import java.util.ArrayList;
+//import java.util.LinkedHashMap;
+//import java.util.ListIterator;
+//
+//import static org.junit.Assert.*;
+//
+///**
+// * Created by Milan_Verheij on 10-06-16.
+// *
+// * J-Unit testClass van KlantDAOMySQL
+// *
+// * Het betreffen hoofdzakelijk basis CRUD-methoden.
+// *
+// * Bijzonderheden zijn dat de get-methoden ListIterators van LinkedLists teruggeven, het Klant-specifieke deel
+// * is opgenomen in een specifieke methode om een ResultSet naar een ArrayList van Klanten te zetten. De ResultSet
+// * naar ArrayList methode wordt impliciet getest in de meeste methoden omdat bijna elke methode hiervan afhankelijk
+// * is.
+// *
+// * Derhalve wordt er niet getest of de getmethoden op een juiste manier een ArrayList naar een Iterator zetten
+// * omdat dit een standaard librarymethode is. ArrayList.listIterator. Als er een List-Iterator terugkomt is
+// * de validiteit hiervan afhankelijk van eerdergenoemde methode en de uitgevoerde query.
+// *
+// */
+//public class KlantDAOMySQLTest {
+//    private KlantDAOMySQL klantDAO;
+//    private BestellingDAOMySQL bestellingDAO;
+//    private long nieuweKlantID;
+//    private Klant tijdelijkeKlant;
+//    private boolean nieuweKlantAangemaakt = false;
+//    private final String VOORNAAM = "TestKlantVoornaam4101AR1225"; // Uniek ID  TODO: Random generator kan nog (nice to have)
+//    private final String ACHTERNAAM = "TestKlantAchternaam4101AR1225"; // Uniek ID TODO: Random generator kan nog (nice to have)
+//    private final String TUSSENVOEGSEL = "TUSS";
+//    private final String EMAIL = "TestEmail@EmailLand.rsvier";
+//    private final String STRAATNAAM = "TestStraatnaam9548";
+//    private final String POSTCODE = "9548ZZ" ;
+//    private final String TOEVOEGING = "ABC";
+//    private final int HUISNUMMER = 9548;
+//    private final String WOONPLAATS = "TestWoonplaats9548";
+//    private Connection connection;
+//    private PreparedStatement statement;
+//    private ResultSet rs;
+//
+//    @Before
+//    public void setUp() throws Exception {
+//        klantDAO = new KlantDAOMySQL();
+//        bestellingDAO = new BestellingDAOMySQL();
+//    }
+//
+//    @After
+//    public void tearDown() throws Exception {
+//        // Vangnet
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
+//        MySQLHelper.close(connection, statement, rs);
+//
+//        AdresDAOMySQL.klantWordtGetest = false; // Mocht er iets fout zijn gegaan in de tests..
+//    }
+//
+//    // De nieuwe klant-methoden zijn helaas afhankelijk van de get-methoden om te kunnen vaststellen
+//    // dat de DATA inderdaad juiste in de MYSQL-database is opgenomen.
+//    // Tijdens de nieuwe klant methoden wordt ook direct getest of er wel een ID wordt aangemaakt en teruggeven.
+//    // Het is niet zinvol dit los te testen.
+//
+//    @Test
+//    public void nieuweKlantVoorAchternaamAdresNullIsLeeg() throws Exception {
+//
+//        // De nieuwe klant-methode met voor, achternaam en Adres gebruikt de nieuweKlant methode met alle
+//        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
+//        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
+//        //
+//        // Als er geen adresgegevens worden meegegeven (null) wordt er standaard een leeg
+//        // Adres aangemaakt omdat er null wordt meegegeven naar de AdresDAO. Aldaar wordt als er null
+//        // wordt geconstateerd een leeg adres gemaakt (dit valt buiten de scope van deze test).
+//        //
+//        // Deze methode test niet of dat de juiste gegevens naar de database worden verstuurd, dat doet
+//        // de AdresDAOMySQLTest. Er wordt enkel gekeken of de juiste gegevens zijn doorgegeven aan AdresDAO (null)
+//        // Dit kan doordat AdresDAOMySQL test of dat haar testwaarde op true staat en als dit het geval is
+//        // wordt het adres tijdelijk opgeslagen.
+//
+//        nieuweKlantAangemaakt = true;
+//        AdresDAOMySQL.klantWordtGetest = true; // Testconditie in AdresDAOMySQL goed zetten.
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, null);
+//
+//        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
+//
+//        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
+//        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
+//        assertTrue((AdresDAOMySQL.aangeroepenAdresInTest == null));
+//
+//
+//        AdresDAOMySQL.klantWordtGetest = false;
+//        tijdelijkeKlant = null;
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void nieuweKlantAdresMethodeJuistAangesproken() throws Exception {
+//
+//        // De nieuwe klant-methode met voor, achternaam en Adres gebruikt de nieuweKlant methode met alle
+//        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
+//        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
+//        //
+//        // Als er geen adresgegevens worden meegegeven (null) wordt er standaard een leeg
+//        // Adres aangemaakt. Het aanmaken (of eigenlijk updaten o.b.v. klantID wordt afzonderlijk getest
+//        //
+//        // Deze methode test niet of dat de juiste gegegevens worden geschreven naar de Database. Het kan echter
+//        // wel voorkomen dat als deze methode en fout geeft omdat er een fout is tijdens het schrijven naar de Database
+//        // dat de test faalt.
+//        //
+//        // Het test verder enkel of dat de AdresDAO met de juiste gegevens is aangesproken.
+//        //
+//        // Dit is het geval als het testAdres-object (static) in de AdresDAO op de juiste gegevens staan.
+//        // Er wordt in AdresDAO gekeken of er toevallig getest wordt, als ja dan wordt het test adres tijdelijk
+//        // opgeslagen in AdresDAOMySQL.aangeroepenAdresInTest.
+//
+//        nieuweKlantAangemaakt = true;
+//        AdresDAOMySQL.klantWordtGetest = true; // Testconditie in AdresDAOMySQL goed zetten.
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM,
 //                new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS));
-
-        // Controleer of de juiste adresgegevens zijn meegegeven aan Adres
-        assertEquals(STRAATNAAM, AdresDAOMySQL.aangeroepenAdresInTest.getStraatnaam());
-        assertEquals(POSTCODE, AdresDAOMySQL.aangeroepenAdresInTest.getPostcode());
-        assertEquals(TOEVOEGING, AdresDAOMySQL.aangeroepenAdresInTest.getToevoeging());
-        assertEquals(HUISNUMMER, AdresDAOMySQL.aangeroepenAdresInTest.getHuisnummer());
-        assertEquals(WOONPLAATS, AdresDAOMySQL.aangeroepenAdresInTest.getWoonplaats());
-
-        tijdelijkeKlant = null;
-        AdresDAOMySQL.aangeroepenAdresInTest = null; // Resetten ADRES
-        AdresDAOMySQL.klantWordtGetest = false;
-    }
-
-    @Test
-    public void updateKlantJuisteBestellingGegevensMeegegeven() throws Exception {
-        // TODO: Zie verwijdermethode, Albert
-    }
-
-    @Test
-    public void verwijderKlantOpID() throws Exception {
-        // Deze methode test of dat een aangemaakte klant daadwerkelijk wordt verwijderd als het juiste klantID
-        // wordt meegeven.
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM);
-
-        klantDAO.schakelStatusKlant(nieuweKlantID, 0);
-
-        // Als het klant_ID niet meer in de lijst voorkomt wanneer er gezocht wordt op klantID klopt dit
-        ListIterator<Klant> klantenLijst = klantDAO.getKlantOpKlant(nieuweKlantID);
-        while (klantenLijst.hasNext()) {
-            tijdelijkeKlant = klantenLijst.next();
-            assertTrue(tijdelijkeKlant.getKlant_id() != nieuweKlantID);
-        }
-
-        tijdelijkeKlant = null;
-    }
-
-    @Test
-    public void verwijderKlantOpVoorAchternaam() throws Exception {
-        // Deze methode test of dat een aangemaakte klant daadwerkelijk wordt verwijderd als de juiste
-        // voor- en achternaam worden meegegeven.
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM);
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
-
-        // Als het klant_ID niet meer in de lijst voorkomt wanneer er gezocht wordt op klantID klopt dit
-        ListIterator<Klant> klantenLijst = klantDAO.getKlantOpKlant(nieuweKlantID);
-        while (klantenLijst.hasNext()) {
-            tijdelijkeKlant = klantenLijst.next();
-            assertTrue(tijdelijkeKlant.getKlant_id() != nieuweKlantID);
-        }
-
-        tijdelijkeKlant = null;
-    }
-
-    @Test
-    public void verwijderKlantOpVoorAchterNaamTussenv() throws Exception {
-        // Deze methode test of dat een aangemaakte klant daadwerkelijk wordt verwijderd als de juiste
-        // voor, achternaam en tussenvoegsel worden meegegeven.
-        nieuweKlantAangemaakt = true;
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, "", 0, null, null);
-
-        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL);
-
-        // Als het klant_ID niet meer in de lijst voorkomt wanneer er gezocht wordt op klantID klopt dit
-        ListIterator<Klant> klantenLijst = klantDAO.getKlantOpKlant(nieuweKlantID);
-        while (klantenLijst.hasNext()) {
-            tijdelijkeKlant = klantenLijst.next();
-            assertTrue(tijdelijkeKlant.getKlant_id() != nieuweKlantID);
-        }
-
-        tijdelijkeKlant = null;
-    }
-
-    @Test
-    public void verwijderKlantOpBestellingId() throws Exception {
-        // In deze test wordt niet getest of dat de bestelling daadwerkelijk verwijderd is. Er wordt gelinkt
-        // naar de verwijderKlantOpID methode welke hiervoor al is getest. Er wordt wel getest of de juiste
-        // klant naar de BestellingDAO is gestuurd.
-        //
-        // Er wordt een nieuwe klant gemaakt met een bestelling waarna deze wordt verwijderd.
-
-        BestellingDAOMySQL.bestellingWordGetest = true;
-
-        // Nieuwe klant aanmaken en klantID achterhalen, wordt altijd in teardown weer verwijderd
-        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
-
-        // Aan de hand van klantID een bestelling toevoegen aan de klant. Is getest in test hierboven.
-        long nieuweBestellingID = bestellingDAO.nieuweBestelling(nieuweKlantID,
-                                new Artikel(333, "Mecronomicon", 3.33),
-                                new Artikel(321, "Woynich Manuscript", 3.21),
-                                new Artikel(888, "Nunich Manual of Demonic Magic", 8.88));
-
-        // Klantverwijder methode aanroepen op basis van bestelling-ID
-        long verwijderdId = klantDAO.verwijderKlantOpBestellingId(nieuweBestellingID);
-
-        // Als het goed is zou de juiste klant gevonden moeten zijn en het juiste klant_id doorgegeven
-        assertEquals(nieuweKlantID, verwijderdId);
-
-        BestellingDAOMySQL.bestellingWordGetest = false;
-        BestellingDAOMySQL.aangeroepenBestellingInTest = new Bestelling(1,
-                new Artikel(666, "Necronomicon", 6.66),
-                new Artikel(123, "Voynich Manuscript", 1.23),
-                new Artikel(999, "Munich Manual of Demonic Magic", 9.99));
-
-        nieuweKlantID = -1;
-    }
-}
+//
+//        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
+//
+//        assertEquals(STRAATNAAM, AdresDAOMySQL.aangeroepenAdresInTest.getStraatnaam());
+//        assertEquals(POSTCODE, AdresDAOMySQL.aangeroepenAdresInTest.getPostcode());
+//        assertEquals(TOEVOEGING, AdresDAOMySQL.aangeroepenAdresInTest.getToevoeging());
+//        assertEquals(HUISNUMMER, AdresDAOMySQL.aangeroepenAdresInTest.getHuisnummer());
+//        assertEquals(WOONPLAATS, AdresDAOMySQL.aangeroepenAdresInTest.getWoonplaats());
+//
+//        AdresDAOMySQL.aangeroepenAdresInTest = null; // Resetten TestAdres
+//        AdresDAOMySQL.klantWordtGetest = false;
+//        tijdelijkeKlant = null;
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void nieuweKlantVoorAchternaam() throws Exception {
+//        // De nieuwe klant-methode met voor- en achternaam gebruikt de nieuweKlant methode met alle
+//        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
+//        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
+//        // TODO: IVM koppeling tussen methoden, allicht een Klant laten returnen en die checken?
+//
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM);
+//
+//        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
+//
+//        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
+//        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
+//
+//        tijdelijkeKlant = null; // TODO: OVeral fixen met wat het wel meot zijn
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void nieuweKlant() throws Exception {
+//        // In deze methode wordt getest of dat alle gegevens juist naar de database worden weggeschreven
+//        // als er zowel een Adres als Bestelling wordt meegegeven.
+//        //
+//        // Er wordt niet getest of de juiste Adres en / of Bestelgegevens worden meegegeven naar de Adres
+//        // en / of BestelDAO. Dat wordt in de hieropvolgende tests getest.
+//
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0,
+//                null, null);
+//
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
+//
+//        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
+//        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
+//        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
+//        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
+//
+//        tijdelijkeKlant = null;
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void nieuweKlantEnBestelling() throws Exception {
+//        // TODO: Overleg met Albert ivm boolean en testBestelObject
+//        // De nieuwe klant-methode met voor, achternaam en Beslling gebruikt de nieuweKlant methode met alle
+//        // klantgegevens en/of adres & bestelling. Derhalve wordt in deze test eigenlijk een juiste
+//        // koppeling getest als de nieuweKlant methode met alle gegevens werkt.
+//        //
+//        // Als er geen Bestelgegevens worden meegegeven (null) wordt er standaard een lege
+//        // Bestelling aangemaakt. Het aanmaken (of eigenlijk updaten o.b.v. klantID wordt afzonderlijk getest
+//        //
+//        // Deze methode test niet of dat de juiste gegegevens worden geschreven naar de Database. Het kan echter
+//        // wel voorkomen dat als deze methode en fout geeft omdat er een fout is tijdens het schrijven naar de Database
+//        // dat de test faalt.
+//        //
+//        // Het test verder enkel of dat de BestellingDAO met de juiste gegevens is aangesproken.
+//        //
+//        // Dit is het geval als het testAdres-object (static) in de BestellingDAO op de juiste gegevens staan.
+//        // Er wordt in Bestelling gekeken of er toevallig getest wordt, als ja dan wordt het test adres tijdelijk
+//        // opgeslagen in BestellingDAOMySQL.aangeroepenAdresInTest.
+//
+//        nieuweKlantAangemaakt = true;
+//        BestellingDAOMySQL.bestellingWordGetest = true; // Testconditie in BestellingDAOMySQL goed zetten.
+//        Artikel a1 = new Artikel(333, "Mecronomicon", 3.33);
+//        Artikel a2 = new Artikel(321, "Woynich Manuscript", 3.21);
+//        Artikel a3 = new Artikel(888, "Nunich Manual of Demonic Magic", 8.88);
+//
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null,
+//                                new Bestelling(0, a1, a2, a3)); // ID wordt in de nieuweKlant methode op het juiste ID geze,
+//
+//        assertTrue(nieuweKlantID != 0); // Zeker van zijn dat er wel een goed ID wordt gegeven.
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next(); // Methode geeft ListIterator terug.
+//
+//        assertEquals(nieuweKlantID, BestellingDAOMySQL.aangeroepenBestellingInTest.getKlant_id());
+//        LinkedHashMap<Artikel, Integer> artikelLijst = BestellingDAOMySQL.aangeroepenBestellingInTest.getArtikelLijst();
+//
+//        // In de bestelling moeten de volgende artikelen 1 x aanwezig zijn
+//        // Er mogen niet meer dan drie artikelen aanwezig zijn.
+//        assertTrue(artikelLijst.size() == 3);
+//        assertEquals(1, (long)artikelLijst.get(a1));
+//        assertEquals(1, (long)artikelLijst.get(a2));
+//        assertEquals(1, (long)artikelLijst.get(a3));
+//
+//        // Alle waarden weer naar default
+//        BestellingDAOMySQL.bestellingWordGetest = false;
+//        BestellingDAOMySQL.aangeroepenBestellingInTest = new Bestelling(1,
+//                new Artikel(666, "Necronomicon", 6.66),
+//                new Artikel(123, "Voynich Manuscript", 1.23),
+//                new Artikel(999, "Munich Manual of Demonic Magic", 9.99));
+//        tijdelijkeKlant = null;
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void getAlleKlanten() throws Exception {
+//        // Deze test controleert of daadwerkelijk alle klanten worden opgevraagd en zijn gegeven.
+//        // Er wordt een query uitgevoerd om te peilen hoeveel klanten er zijn waarna deze wordt vergeleken
+//        // met de grootte van de lijst.
+//
+//        connection = MySQLConnectieLeverancier.getConnection();
+//        String query = "SELECT COUNT(*) FROM KLANT";
+//        statement = connection.prepareStatement(query);
+//        rs = statement.executeQuery();
+//        int aantalKlantenInDB = 0;
+//        int aantalKlantenInList = 0;
+//
+//        while (rs.next())
+//            aantalKlantenInDB = rs.getInt(1);
+//
+//        ListIterator<Klant> klantenIterator = klantDAO.getAlleKlanten();
+//        while (klantenIterator.hasNext()) {
+//            klantenIterator.next();
+//            aantalKlantenInList++;
+//        }
+//
+//        assertEquals(aantalKlantenInDB, aantalKlantenInList);
+//
+//        MySQLHelper.close(connection, statement, rs);
+//    }
+//
+//    @Test
+//    public void getKlantOpKlant() throws Exception {
+//        // Deze methode test of dat de juiste klant wordt gevonden op basis van klantID
+//
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
+//
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next();
+//
+//        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
+//        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
+//        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
+//        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
+//
+//        tijdelijkeKlant = null;
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void getKlantOpKlantVoornaam() throws Exception {
+//        // Deze methode test of dat de juiste klant wordt gevonden op basis van voornaam
+//        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
+//        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
+//        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
+//        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
+//
+//        nieuweKlantAangemaakt = true;
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL + "2", EMAIL + "2",0, null, null);
+//
+//        ListIterator<Klant> klantIterator = klantDAO.getKlantOpKlant(VOORNAAM);
+//        ArrayList<Klant> klantenLijst = new ArrayList<>();
+//        while (klantIterator.hasNext()) {
+//            klantenLijst.add(klantIterator.next());
+//        }
+//
+//        assertEquals(VOORNAAM, klantenLijst.get(0).getVoornaam());
+//        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
+//        assertEquals(TUSSENVOEGSEL, klantenLijst.get(0).getTussenvoegsel());
+//        assertEquals(EMAIL, klantenLijst.get(0).getEmail());
+//
+//        assertEquals(VOORNAAM, klantenLijst.get(1).getVoornaam());
+//        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
+//        assertEquals(TUSSENVOEGSEL + "2", klantenLijst.get(1).getTussenvoegsel());
+//        assertEquals(EMAIL + "2", klantenLijst.get(1).getEmail());
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
+//    }
+//
+//    @Test
+//    public void getKlantOpKlantVoornaamAchternaam() throws Exception {
+//        // Deze methode test of dat de juiste klant wordt gevonden op basis van voornaam en achternaam
+//        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
+//        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
+//        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
+//        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
+//
+//        nieuweKlantAangemaakt = true;
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL,0, null, null);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL + "2", EMAIL + "2", 0, null, null);
+//
+//        ListIterator<Klant> klantIterator = klantDAO.getKlantOpKlant(VOORNAAM);
+//        ArrayList<Klant> klantenLijst = new ArrayList<>();
+//        while (klantIterator.hasNext()) {
+//            klantenLijst.add(klantIterator.next());
+//        }
+//
+//        assertEquals(VOORNAAM, klantenLijst.get(0).getVoornaam());
+//        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
+//        assertEquals(TUSSENVOEGSEL, klantenLijst.get(0).getTussenvoegsel());
+//        assertEquals(EMAIL, klantenLijst.get(0).getEmail());
+//
+//        assertEquals(VOORNAAM, klantenLijst.get(1).getVoornaam());
+//        assertEquals(ACHTERNAAM, klantenLijst.get(1).getAchternaam());
+//        assertEquals(TUSSENVOEGSEL + "2", klantenLijst.get(1).getTussenvoegsel());
+//        assertEquals(EMAIL + "2", klantenLijst.get(1).getEmail());
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//    }
+//
+//    @Test
+//    public void getKlantOpVolledigAdres() throws Exception {
+//        // Deze methode test of dat de juiste klant wordt gevonden op basis van de volledige adresdegevens
+//        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
+//        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
+//        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
+//        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
+//
+//        nieuweKlantAangemaakt = true;
+//        Adres tijdelijkAdres = new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
+//
+//        ListIterator<Klant> klantIterator = klantDAO.getKlantOpAdres(tijdelijkAdres);
+//        ArrayList<Klant> klantenLijst = new ArrayList<>();
+//        while (klantIterator.hasNext()) {
+//            klantenLijst.add(klantIterator.next());
+//        }
+//
+//        // Check op klant 1 gevonden
+//        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
+//
+//        // Check of klant twee ook werd gevonden
+//        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
+//    }
+//
+//    @Test
+//    public void getKlantOpAdresStraatnaam() throws Exception {
+//        // Deze methode test of dat de juiste klant wordt gevonden op basis van de straatnaam
+//        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
+//        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
+//        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
+//        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
+//
+//        nieuweKlantAangemaakt = true;
+//        Adres tijdelijkAdres = new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
+//
+//        ListIterator<Klant> klantIterator = klantDAO.getKlantOpAdres(STRAATNAAM);
+//        ArrayList<Klant> klantenLijst = new ArrayList<>();
+//        while (klantIterator.hasNext()) {
+//            klantenLijst.add(klantIterator.next());
+//        }
+//
+//        // Check op klant 1 gevonden
+//        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
+//
+//        // Check of klant twee ook werd gevonden
+//        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
+//        tijdelijkeKlant = null;
+//    }
+//
+//    @Test
+//    public void getKlantOpAdresPostcodeHuisNR() throws Exception {
+//        // Deze methode test of dat de juiste klant wordt gevonden op basis van de postcode en het huisnummer
+//        // Om te controleren of daadwerkelijke alle klanten met dezelfde voornaam worden
+//        // meegegeven worden er twee klanten met dezelfde voornaam aangemaakt. Maar met
+//        // net andere andere gegegevens. Vervolgens wordt nagegaan of deze gegevens ook
+//        // daadwerkelijk zijn teruggegeven. Vervolgens worden deze klanten weer verwijderd.
+//
+//        nieuweKlantAangemaakt = true;
+//        Adres tijdelijkAdres = new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
+//        klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM + "2", TUSSENVOEGSEL, EMAIL, 0, tijdelijkAdres, null);
+//
+//        ListIterator<Klant> klantIterator = klantDAO.getKlantOpAdres(POSTCODE, HUISNUMMER);
+//        ArrayList<Klant> klantenLijst = new ArrayList<>();
+//        while (klantIterator.hasNext()) {
+//            klantenLijst.add(klantIterator.next());
+//        }
+//
+//        // Check op klant 1 gevonden
+//        assertEquals(ACHTERNAAM, klantenLijst.get(0).getAchternaam());
+//
+//        // Check of klant twee ook werd gevonden
+//        assertEquals(ACHTERNAAM + "2", klantenLijst.get(1).getAchternaam());
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM + "2");
+//        tijdelijkeKlant = null;
+//    }
+//
+//    @Test
+//    public void getKlantOpBestelling() throws Exception {
+//        // Deze methode checkt of dat de juiste klant worden opgehaald op basis van
+//        // het opgegeven Bestel_ID
+//
+//        // Er wordt een nieuwe klant gemaakt met een bestelling waarna deze wordt verwijderd.
+//        BestellingDAOMySQL.bestellingWordGetest = true;
+//
+//        // Nieuwe klant aanmaken en klantID achterhalen, wordt altijd in teardown weer verwijderd
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
+//
+//        // Aan de hand van klantID een bestelling toevoegen aan de klant. Is getest in test hierboven.
+//        long nieuweBestellingID = bestellingDAO.nieuweBestelling(nieuweKlantID,
+//                new Artikel(333, "Mecronomicon", 3.33),
+//                new Artikel(321, "Woynich Manuscript", 3.21),
+//                new Artikel(888, "Nunich Manual of Demonic Magic", 8.88));
+//
+//        tijdelijkeKlant = klantDAO.getKlantOpBestelling(nieuweBestellingID).next();
+//
+//        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
+//        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
+//        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
+//        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
+//
+//        // Alle waarden weer resetten naar default
+//        tijdelijkeKlant = null;
+//        BestellingDAOMySQL.bestellingWordGetest = false;
+//        BestellingDAOMySQL.aangeroepenBestellingInTest = new Bestelling(1,
+//                new Artikel(666, "Necronomicon", 6.66),
+//                new Artikel(123, "Voynich Manuscript", 1.23),
+//                new Artikel(999, "Munich Manual of Demonic Magic", 9.99));
+//
+//        nieuweKlantID = -1;
+//    }
+//
+//    @Test
+//    public void updateKlantGegeven() throws Exception {
+//        // Deze methode test of de juiste klantGegevens worden geUpdate als een klantID wordt meegegeven
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant("", "", "", "", 0, null, null); // Leeg
+//
+//        klantDAO.updateKlant(nieuweKlantID, VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL);
+//
+//        // Vraag klant op en controleer de inhoud
+//        tijdelijkeKlant = klantDAO.getKlantOpKlant(nieuweKlantID).next();
+//        assertEquals(VOORNAAM, tijdelijkeKlant.getVoornaam());
+//        assertEquals(ACHTERNAAM, tijdelijkeKlant.getAchternaam());
+//        assertEquals(TUSSENVOEGSEL, tijdelijkeKlant.getTussenvoegsel());
+//        assertEquals(EMAIL, tijdelijkeKlant.getEmail());
+//
+//        tijdelijkeKlant = null;
+//    }
+//
+//    @Test
+//    public void updateKlantJuisteAdresGegevensMeegegeven() throws Exception {
+//        // Deze methode test niet of dat de juiste gegevens in de database worden geschreven, dat wordt
+//        // in de methode hierboven gedaan. Die methode wordt ook simpelweg aangeroepen in deze methode.
+//        // Deze methode test of de juiste klantGegevens worden geUpdate als een klantID wordt meegegeven
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant("", "", "", "", 0, null, null); // Leeg
+//
+//        AdresDAOMySQL.klantWordtGetest = true;
+////        klantDAO.updateKlant(nieuweKlantID, VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL,
+////                new Adres(STRAATNAAM, POSTCODE, TOEVOEGING, HUISNUMMER, WOONPLAATS));
+//
+//        // Controleer of de juiste adresgegevens zijn meegegeven aan Adres
+//        assertEquals(STRAATNAAM, AdresDAOMySQL.aangeroepenAdresInTest.getStraatnaam());
+//        assertEquals(POSTCODE, AdresDAOMySQL.aangeroepenAdresInTest.getPostcode());
+//        assertEquals(TOEVOEGING, AdresDAOMySQL.aangeroepenAdresInTest.getToevoeging());
+//        assertEquals(HUISNUMMER, AdresDAOMySQL.aangeroepenAdresInTest.getHuisnummer());
+//        assertEquals(WOONPLAATS, AdresDAOMySQL.aangeroepenAdresInTest.getWoonplaats());
+//
+//        tijdelijkeKlant = null;
+//        AdresDAOMySQL.aangeroepenAdresInTest = null; // Resetten ADRES
+//        AdresDAOMySQL.klantWordtGetest = false;
+//    }
+//
+//    @Test
+//    public void updateKlantJuisteBestellingGegevensMeegegeven() throws Exception {
+//        // TODO: Zie verwijdermethode, Albert
+//    }
+//
+//    @Test
+//    public void verwijderKlantOpID() throws Exception {
+//        // Deze methode test of dat een aangemaakte klant daadwerkelijk wordt verwijderd als het juiste klantID
+//        // wordt meegeven.
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM);
+//
+//        klantDAO.schakelStatusKlant(nieuweKlantID, 0);
+//
+//        // Als het klant_ID niet meer in de lijst voorkomt wanneer er gezocht wordt op klantID klopt dit
+//        ListIterator<Klant> klantenLijst = klantDAO.getKlantOpKlant(nieuweKlantID);
+//        while (klantenLijst.hasNext()) {
+//            tijdelijkeKlant = klantenLijst.next();
+//            assertTrue(tijdelijkeKlant.getKlant_id() != nieuweKlantID);
+//        }
+//
+//        tijdelijkeKlant = null;
+//    }
+//
+//    @Test
+//    public void verwijderKlantOpVoorAchternaam() throws Exception {
+//        // Deze methode test of dat een aangemaakte klant daadwerkelijk wordt verwijderd als de juiste
+//        // voor- en achternaam worden meegegeven.
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM);
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM);
+//
+//        // Als het klant_ID niet meer in de lijst voorkomt wanneer er gezocht wordt op klantID klopt dit
+//        ListIterator<Klant> klantenLijst = klantDAO.getKlantOpKlant(nieuweKlantID);
+//        while (klantenLijst.hasNext()) {
+//            tijdelijkeKlant = klantenLijst.next();
+//            assertTrue(tijdelijkeKlant.getKlant_id() != nieuweKlantID);
+//        }
+//
+//        tijdelijkeKlant = null;
+//    }
+//
+//    @Test
+//    public void verwijderKlantOpVoorAchterNaamTussenv() throws Exception {
+//        // Deze methode test of dat een aangemaakte klant daadwerkelijk wordt verwijderd als de juiste
+//        // voor, achternaam en tussenvoegsel worden meegegeven.
+//        nieuweKlantAangemaakt = true;
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, "", 0, null, null);
+//
+//        klantDAO.schakelStatusKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL);
+//
+//        // Als het klant_ID niet meer in de lijst voorkomt wanneer er gezocht wordt op klantID klopt dit
+//        ListIterator<Klant> klantenLijst = klantDAO.getKlantOpKlant(nieuweKlantID);
+//        while (klantenLijst.hasNext()) {
+//            tijdelijkeKlant = klantenLijst.next();
+//            assertTrue(tijdelijkeKlant.getKlant_id() != nieuweKlantID);
+//        }
+//
+//        tijdelijkeKlant = null;
+//    }
+//
+//    @Test
+//    public void verwijderKlantOpBestellingId() throws Exception {
+//        // In deze test wordt niet getest of dat de bestelling daadwerkelijk verwijderd is. Er wordt gelinkt
+//        // naar de verwijderKlantOpID methode welke hiervoor al is getest. Er wordt wel getest of de juiste
+//        // klant naar de BestellingDAO is gestuurd.
+//        //
+//        // Er wordt een nieuwe klant gemaakt met een bestelling waarna deze wordt verwijderd.
+//
+//        BestellingDAOMySQL.bestellingWordGetest = true;
+//
+//        // Nieuwe klant aanmaken en klantID achterhalen, wordt altijd in teardown weer verwijderd
+//        nieuweKlantID = klantDAO.nieuweKlant(VOORNAAM, ACHTERNAAM, TUSSENVOEGSEL, EMAIL, 0, null, null);
+//
+//        // Aan de hand van klantID een bestelling toevoegen aan de klant. Is getest in test hierboven.
+//        long nieuweBestellingID = bestellingDAO.nieuweBestelling(nieuweKlantID,
+//                                new Artikel(333, "Mecronomicon", 3.33),
+//                                new Artikel(321, "Woynich Manuscript", 3.21),
+//                                new Artikel(888, "Nunich Manual of Demonic Magic", 8.88));
+//
+//        // Klantverwijder methode aanroepen op basis van bestelling-ID
+//        long verwijderdId = klantDAO.verwijderKlantOpBestellingId(nieuweBestellingID);
+//
+//        // Als het goed is zou de juiste klant gevonden moeten zijn en het juiste klant_id doorgegeven
+//        assertEquals(nieuweKlantID, verwijderdId);
+//
+//        BestellingDAOMySQL.bestellingWordGetest = false;
+//        BestellingDAOMySQL.aangeroepenBestellingInTest = new Bestelling(1,
+//                new Artikel(666, "Necronomicon", 6.66),
+//                new Artikel(123, "Voynich Manuscript", 1.23),
+//                new Artikel(999, "Munich Manual of Demonic Magic", 9.99));
+//
+//        nieuweKlantID = -1;
+//    }
+//}

--- a/src/connection_pools/C3POAdapter.java
+++ b/src/connection_pools/C3POAdapter.java
@@ -13,7 +13,7 @@ import java.sql.SQLException;
  *
  */
 public class C3POAdapter implements VerkrijgConnectie {
-    c3poDataSource c3PODataSource;
+    C3POConnectionPool C3POConnectionPool;
     private int DBKeuze;
 
     public C3POAdapter(int DBKeuze) throws RSVIERException {
@@ -23,7 +23,7 @@ public class C3POAdapter implements VerkrijgConnectie {
     @Override
     public Connection verkrijgConnectie() throws RSVIERException {
         try {
-        return c3PODataSource.getInstance(DBKeuze).getConnection();
+        return C3POConnectionPool.getInstance(DBKeuze).getConnection();
         } catch (SQLException ex) {
             throw new RSVIERException("C3POAdapter SQL Exception" + ex.getMessage());
         }

--- a/src/connection_pools/C3POAdapter.java
+++ b/src/connection_pools/C3POAdapter.java
@@ -9,16 +9,32 @@ import java.sql.SQLException;
 /**
  * Created by Milan_Verheij on 19-06-16.
  *
- * Adapter voor de C3PO Connection Pool voor diverse Databases.
+ * Adapter voor de C3PO Connection Pool.
+ * Implementeert de VerkrijgConnectie interface welke gebruikt
+ * waardoor deze een verkrijgConnectie methode diente te implementeren.
  *
  */
 public class C3POAdapter implements VerkrijgConnectie {
     private int DBKeuze;
 
+    /**
+     * Standaard C3PO Adapter.
+     *
+     * @param DBKeuze Keuze van het type database welke door de connection pool
+     *                gebruikt moet worden.
+     * @throws RSVIERException Geeft een foutmelding met bijhorende melding.
+     */
     public C3POAdapter(int DBKeuze) throws RSVIERException {
         this.DBKeuze = DBKeuze;
     }
 
+    /**
+     * Retourneert een Connection object aangeleverd door een van de
+     * connection pools welke deze interface implementeren.
+     *
+     * @return Een connection object van een van de connection pools.
+     * @throws RSVIERException Gooit een fout terug met de bijbehorende message.
+     */
     @Override
     public Connection verkrijgConnectie() throws RSVIERException {
         try {

--- a/src/connection_pools/C3POAdapter.java
+++ b/src/connection_pools/C3POAdapter.java
@@ -1,0 +1,31 @@
+package connection_pools;
+
+import exceptions.RSVIERException;
+import interfaces.VerkrijgConnectie;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Created by Milan_Verheij on 19-06-16.
+ *
+ * Adapter voor de C3PO Connection Pool voor diverse Databases.
+ *
+ */
+public class C3POAdapter implements VerkrijgConnectie {
+    c3poDataSource c3PODataSource;
+    private int DBKeuze;
+
+    public C3POAdapter(int DBKeuze) throws RSVIERException {
+        this.DBKeuze = DBKeuze;
+    }
+
+    @Override
+    public Connection verkrijgConnectie() throws RSVIERException {
+        try {
+        return c3PODataSource.getInstance(DBKeuze).getConnection();
+        } catch (SQLException ex) {
+            throw new RSVIERException("C3POAdapter SQL Exception" + ex.getMessage());
+        }
+    }
+}

--- a/src/connection_pools/C3POConnectionPool.java
+++ b/src/connection_pools/C3POConnectionPool.java
@@ -13,8 +13,8 @@ import java.sql.SQLException;
  * AANPASSEN
  *
  */
-public class c3poDataSource {
-    private static connection_pools.c3poDataSource c3poDataSource;
+public class C3POConnectionPool {
+    private static C3POConnectionPool C3POConnectionPool;
     private ComboPooledDataSource cpds;
 
     private static final String MYSQL_URL = "jdbc:mysql://milanverheij.nl/RSVIERPROJECTDEEL2";
@@ -22,7 +22,7 @@ public class c3poDataSource {
     private static final String MYSQL_PASSWORD = "slechtwachtwoord";
     private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.Driver";
 
-    private c3poDataSource(int DBKeuze) throws RSVIERException {
+    private C3POConnectionPool(int DBKeuze) throws RSVIERException {
         if (DBKeuze == 1) {
             try {
                 cpds = new ComboPooledDataSource();
@@ -38,12 +38,12 @@ public class c3poDataSource {
         }
     }
 
-    public static connection_pools.c3poDataSource getInstance(int DBKeuze) throws RSVIERException {
-        if (c3poDataSource == null) {
-            c3poDataSource = new c3poDataSource(DBKeuze);
-            return c3poDataSource;
+    public static C3POConnectionPool getInstance(int DBKeuze) throws RSVIERException {
+        if (C3POConnectionPool == null) {
+            C3POConnectionPool = new C3POConnectionPool(DBKeuze);
+            return C3POConnectionPool;
         } else {
-            return c3poDataSource;
+            return C3POConnectionPool;
         }
     }
 

--- a/src/connection_pools/C3POConnectionPool.java
+++ b/src/connection_pools/C3POConnectionPool.java
@@ -10,9 +10,12 @@ import java.sql.SQLException;
 /**
  * Created by Milan_Verheij on 19-06-16.
  *
- * AANPASSEN
+ * C3PO Connection Pool
  *
+ * Configuratie Object en uiteindelijke leverancier van 'C3PO-Connecties'.
+ * Levert enkel connecties op basis van het meegegeven DataBase Type.
  */
+
 public class C3POConnectionPool {
     private static C3POConnectionPool C3POConnectionPool;
     private ComboPooledDataSource cpds;
@@ -22,6 +25,12 @@ public class C3POConnectionPool {
     private static final String MYSQL_PASSWORD = "slechtwachtwoord";
     private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.Driver";
 
+    /**
+     * Stelt de C3PO configuratie in op het gekozen DataBase type.
+     *
+     * @param DBKeuze Keuze voor het type database (1 = MySQL, 2 = FireBird);
+     * @throws RSVIERException Foutmelding met gegevens.
+     */
     private C3POConnectionPool(int DBKeuze) throws RSVIERException {
         if (DBKeuze == 1) {
             try {
@@ -38,6 +47,13 @@ public class C3POConnectionPool {
         }
     }
 
+    /**
+     * Retourneert een instance van C3POConnectionPool als deze nog niet bestond.
+     *
+     * @param DBKeuze Keuze voor het type database (1 = MySQL, 2 = FireBird);
+     * @return C3PO Connection pool.
+     * @throws RSVIERException Foutmelding met gegevens.
+     */
     public static C3POConnectionPool getInstance(int DBKeuze) throws RSVIERException {
         if (C3POConnectionPool == null) {
             C3POConnectionPool = new C3POConnectionPool(DBKeuze);
@@ -47,6 +63,12 @@ public class C3POConnectionPool {
         }
     }
 
+    /**
+     * Retourneert een connectie behorend bij deze Connection Pool.
+     *
+     * @return Connection-Object.
+     * @throws SQLException Foutmelding met gegevens.
+     */
     public Connection getConnection() throws SQLException {
         return this.cpds.getConnection();
     }

--- a/src/connection_pools/C3POConnectionPool.java
+++ b/src/connection_pools/C3POConnectionPool.java
@@ -6,6 +6,7 @@ import exceptions.RSVIERException;
 import java.beans.PropertyVetoException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * Created by Milan_Verheij on 19-06-16.
@@ -20,10 +21,19 @@ public class C3POConnectionPool {
     private static C3POConnectionPool C3POConnectionPool;
     private ComboPooledDataSource cpds;
 
+
+    // MySQL Settings
     private static final String MYSQL_URL = "jdbc:mysql://milanverheij.nl/RSVIERPROJECTDEEL2";
     private static final String MYSQL_USER = "rsvierproject";
     private static final String MYSQL_PASSWORD = "slechtwachtwoord";
     private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.Driver";
+
+    // FireBird settings
+    private static final String FIREBIRD_URL =
+            "jdbc:firebirdsql://milanverheij.nl:3050//var//lib//firebird//2.5//data//RSVIERPROJECTDEEL2.fdb";
+    private static final String FIREBIRD_USER = "rsvierproject";
+    private static final String FIREBIRD_PASSWORD = "slechtwachtwoord";
+    private static final String FIREBIRD_DRIVER_CLASS = "org.firebirdsql.jdbc.FBDriver";
 
     /**
      * Stelt de C3PO configuratie in op het gekozen DataBase type.
@@ -40,6 +50,22 @@ public class C3POConnectionPool {
                 cpds.setJdbcUrl(MYSQL_URL);
                 cpds.setUser(MYSQL_USER);
                 cpds.setPassword(MYSQL_PASSWORD);
+
+            } catch (PropertyVetoException ex) {
+                throw new RSVIERException("PropertyVetoExcepton in C3PO connection pool");
+            }
+        }
+        else if (DBKeuze == 2) {
+            try {
+                cpds = new ComboPooledDataSource();
+
+                Properties properties = new Properties();
+                properties.setProperty("charSet", "utf-8");
+                cpds.setProperties(properties);
+                cpds.setDriverClass(FIREBIRD_DRIVER_CLASS);
+                cpds.setJdbcUrl(FIREBIRD_URL);
+                cpds.setUser(FIREBIRD_USER);
+                cpds.setPassword(FIREBIRD_PASSWORD);
 
             } catch (PropertyVetoException ex) {
                 throw new RSVIERException("PropertyVetoExcepton in C3PO connection pool");
@@ -70,6 +96,7 @@ public class C3POConnectionPool {
      * @throws SQLException Foutmelding met gegevens.
      */
     public Connection getConnection() throws SQLException {
+
         return this.cpds.getConnection();
     }
 }

--- a/src/connection_pools/HikariCPAdapter.java
+++ b/src/connection_pools/HikariCPAdapter.java
@@ -9,20 +9,18 @@ import java.sql.SQLException;
 /**
  * Created by Milan_Verheij on 19-06-16.
  *
- * Adapter voor de C3PO Connection Pool voor diverse Databases.
- *
  */
-public class C3POAdapter implements VerkrijgConnectie {
+public class HikariCPAdapter implements VerkrijgConnectie {
     private int DBKeuze;
 
-    public C3POAdapter(int DBKeuze) throws RSVIERException {
+    public HikariCPAdapter(int DBKeuze) {
         this.DBKeuze = DBKeuze;
     }
 
     @Override
     public Connection verkrijgConnectie() throws RSVIERException {
         try {
-        return C3POConnectionPool.getInstance(DBKeuze).getConnection();
+            return HikariCPConnectionPool.getInstance(DBKeuze).getConnection();
         } catch (SQLException ex) {
             throw new RSVIERException("C3POAdapter SQL Exception" + ex.getMessage());
         }

--- a/src/connection_pools/HikariCPAdapter.java
+++ b/src/connection_pools/HikariCPAdapter.java
@@ -9,14 +9,31 @@ import java.sql.SQLException;
 /**
  * Created by Milan_Verheij on 19-06-16.
  *
+ * Adapter voor de HikariCP Connection Pool.
+ * Implementeert de VerkrijgConnectie interface welke gebruikt
+ * waardoor deze een verkrijgConnectie methode diente te implementeren.
+ *
  */
 public class HikariCPAdapter implements VerkrijgConnectie {
     private int DBKeuze;
 
+    /**
+     * Standaard HikariCPAdater.
+     *
+     * @param DBKeuze Keuze van het type database welke door de connection pool
+     *                gebruikt moet worden.
+     */
     public HikariCPAdapter(int DBKeuze) {
         this.DBKeuze = DBKeuze;
     }
 
+    /**
+     * Retourneert een Connection object aangeleverd door een van de
+     * connection pools welke deze interface implementeren.
+     *
+     * @return Een connection object van een van de connection pools.
+     * @throws RSVIERException Gooit een fout terug met de bijbehorende message.
+     */
     @Override
     public Connection verkrijgConnectie() throws RSVIERException {
         try {

--- a/src/connection_pools/HikariCPConnectionPool.java
+++ b/src/connection_pools/HikariCPConnectionPool.java
@@ -10,9 +10,12 @@ import java.sql.SQLException;
 /**
  * Created by Milan_Verheij on 19-06-16.
  *
- * AANPASSEN
+ * HikariCP Connection Pool
  *
+ * Configuratie Object en uiteindelijke leverancier van 'HikariCP-Connecties'.
+ * Levert enkel connecties op basis van het meegegeven DataBase Type.
  */
+
 public class HikariCPConnectionPool {
     @SuppressWarnings("unused")
     private static HikariCPConnectionPool hikariCPConnectionPool;
@@ -26,6 +29,12 @@ public class HikariCPConnectionPool {
     private static final String MYSQL_PASSWORD = "slechtwachtwoord";
     private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.jdbc2.optional.MysqlDataSource";
 
+    /**
+     * Stelt de HikariCP configuratie in op het gekozen DataBase type.
+     *
+     * @param DBKeuze Keuze voor het type database (1 = MySQL, 2 = FireBird);
+     * @throws RSVIERException Foutmelding met gegevens.
+     */
     private HikariCPConnectionPool(int DBKeuze) throws RSVIERException {
         if (DBKeuze == 1) {
             hikariConfig = new HikariConfig();
@@ -44,6 +53,13 @@ public class HikariCPConnectionPool {
         }
     }
 
+    /**
+     * Retourneert een instance van HikariCPConnectionPool als deze nog niet bestond.
+     *
+     * @param DBKeuze Keuze voor het type database (1 = MySQL, 2 = FireBird);
+     * @return HikariCP Connection pool.
+     * @throws RSVIERException Foutmelding met gegevens.
+     */
     public static HikariCPConnectionPool getInstance(int DBKeuze) throws RSVIERException {
         if (hikariCPConnectionPool == null) {
             hikariCPConnectionPool = new HikariCPConnectionPool(DBKeuze);
@@ -53,6 +69,12 @@ public class HikariCPConnectionPool {
         }
     }
 
+    /**
+     * Retourneert een connectie behorend bij deze Connection Pool.
+     *
+     * @return Connection-Object.
+     * @throws SQLException Foutmelding met gegevens.
+     */
     public Connection getConnection() throws SQLException, RSVIERException {
         return this.hikariDataSource.getConnection();
     }

--- a/src/connection_pools/HikariCPConnectionPool.java
+++ b/src/connection_pools/HikariCPConnectionPool.java
@@ -29,6 +29,12 @@ public class HikariCPConnectionPool {
     private static final String MYSQL_PASSWORD = "slechtwachtwoord";
     private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.jdbc2.optional.MysqlDataSource";
 
+    private static final String FIREBIRD_DATABASE =
+            "//milanverheij.nl:3050//var//lib//firebird//2.5//data//RSVIERPROJECTDEEL2.fdb";
+    private static final String FIREBIRD_USER = "rsvierproject";
+    private static final String FIREBIRD_PASSWORD = "slechtwachtwoord";
+    private static final String FIREBIRD_DRIVER_CLASS = "org.firebirdsql.pool.FBSimpleDataSource";
+
     /**
      * Stelt de HikariCP configuratie in op het gekozen DataBase type.
      *
@@ -48,6 +54,20 @@ public class HikariCPConnectionPool {
             hikariConfig.addDataSourceProperty("databaseName", MYSQL_DATABASE);
             hikariConfig.addDataSourceProperty("user", MYSQL_USER);
             hikariConfig.addDataSourceProperty("password", MYSQL_PASSWORD);
+
+            hikariDataSource = new HikariDataSource(hikariConfig);
+        }
+
+        if (DBKeuze == 2) {
+            hikariConfig = new HikariConfig();
+            hikariConfig.setMinimumIdle(1);
+            hikariConfig.setMaximumPoolSize(2);
+            hikariConfig.setInitializationFailFast(true);
+
+            hikariConfig.setDataSourceClassName(FIREBIRD_DRIVER_CLASS);
+            hikariConfig.addDataSourceProperty("database", FIREBIRD_DATABASE);
+            hikariConfig.addDataSourceProperty("userName", FIREBIRD_USER);
+            hikariConfig.addDataSourceProperty("password", FIREBIRD_PASSWORD);
 
             hikariDataSource = new HikariDataSource(hikariConfig);
         }

--- a/src/connection_pools/HikariCPConnectionPool.java
+++ b/src/connection_pools/HikariCPConnectionPool.java
@@ -1,0 +1,59 @@
+package connection_pools;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import exceptions.RSVIERException;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Created by Milan_Verheij on 19-06-16.
+ *
+ * AANPASSEN
+ *
+ */
+public class HikariCPConnectionPool {
+    @SuppressWarnings("unused")
+    private static HikariCPConnectionPool hikariCPConnectionPool;
+    private HikariConfig hikariConfig;
+    private HikariDataSource hikariDataSource;
+
+    private static final String MYSQL_SERVERURL = "milanverheij.nl";
+    private static final String MYSQL_SERVERPORT = "3306";
+    private static final String MYSQL_DATABASE = "RSVIERPROJECTDEEL2";
+    private static final String MYSQL_USER = "rsvierproject";
+    private static final String MYSQL_PASSWORD = "slechtwachtwoord";
+    private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.jdbc2.optional.MysqlDataSource";
+
+    private HikariCPConnectionPool(int DBKeuze) throws RSVIERException {
+        if (DBKeuze == 1) {
+            hikariConfig = new HikariConfig();
+            hikariConfig.setMinimumIdle(1);
+            hikariConfig.setMaximumPoolSize(2);
+            hikariConfig.setInitializationFailFast(true);
+
+            hikariConfig.setDataSourceClassName(MYSQL_DRIVER_CLASS);
+            hikariConfig.addDataSourceProperty("serverName", MYSQL_SERVERURL);
+            hikariConfig.addDataSourceProperty("port", MYSQL_SERVERPORT);
+            hikariConfig.addDataSourceProperty("databaseName", MYSQL_DATABASE);
+            hikariConfig.addDataSourceProperty("user", MYSQL_USER);
+            hikariConfig.addDataSourceProperty("password", MYSQL_PASSWORD);
+
+            hikariDataSource = new HikariDataSource(hikariConfig);
+        }
+    }
+
+    public static HikariCPConnectionPool getInstance(int DBKeuze) throws RSVIERException {
+        if (hikariCPConnectionPool == null) {
+            hikariCPConnectionPool = new HikariCPConnectionPool(DBKeuze);
+            return hikariCPConnectionPool;
+        } else {
+            return hikariCPConnectionPool;
+        }
+    }
+
+    public Connection getConnection() throws SQLException, RSVIERException {
+        return this.hikariDataSource.getConnection();
+    }
+}

--- a/src/connection_pools/OudeMySQLConnectorAdapter.java
+++ b/src/connection_pools/OudeMySQLConnectorAdapter.java
@@ -1,0 +1,21 @@
+package connection_pools;
+
+import exceptions.RSVIERException;
+import interfaces.VerkrijgConnectie;
+import mysql.MySQLConnectieLeverancier;
+
+import java.sql.Connection;
+
+/**
+ * Created by Milan_Verheij on 19-06-16.
+ *
+ * Adapter voor onze oude MYSQLConnectie
+ *
+ */
+public class OudeMySQLConnectorAdapter implements VerkrijgConnectie {
+
+    @Override
+    public Connection verkrijgConnectie() throws RSVIERException {
+        return MySQLConnectieLeverancier.getConnection();
+    }
+}

--- a/src/connection_pools/OudeMySQLConnectorAdapter.java
+++ b/src/connection_pools/OudeMySQLConnectorAdapter.java
@@ -9,11 +9,20 @@ import java.sql.Connection;
 /**
  * Created by Milan_Verheij on 19-06-16.
  *
- * Adapter voor onze oude MYSQLConnectie
+ * Adapter voor de 'oude' MySQLConnectieLeverancier
+ * Implementeert de VerkrijgConnectie interface welke gebruikt
+ * waardoor deze een verkrijgConnectie methode diente te implementeren.
  *
  */
 public class OudeMySQLConnectorAdapter implements VerkrijgConnectie {
 
+    /**
+     * Retourneert een Connection object aangeleverd door een van de
+     * connection pools welke deze interface implementeren.
+     *
+     * @return Een connection object van een van de connection pools.
+     * @throws RSVIERException Gooit een fout terug met de bijbehorende message.
+     */
     @Override
     public Connection verkrijgConnectie() throws RSVIERException {
         return MySQLConnectieLeverancier.getConnection();

--- a/src/connection_pools/c3poDataSource.java
+++ b/src/connection_pools/c3poDataSource.java
@@ -1,0 +1,53 @@
+package connection_pools;
+
+import com.mchange.v2.c3p0.*;
+import exceptions.RSVIERException;
+
+import java.beans.PropertyVetoException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Created by Milan_Verheij on 19-06-16.
+ *
+ * AANPASSEN
+ *
+ */
+public class c3poDataSource {
+    private static connection_pools.c3poDataSource c3poDataSource;
+    private ComboPooledDataSource cpds;
+
+    private static final String MYSQL_URL = "jdbc:mysql://milanverheij.nl/RSVIERPROJECTDEEL2";
+    private static final String MYSQL_USER = "rsvierproject";
+    private static final String MYSQL_PASSWORD = "slechtwachtwoord";
+    private static final String MYSQL_DRIVER_CLASS = "com.mysql.jdbc.Driver";
+
+    private c3poDataSource(int DBKeuze) throws RSVIERException {
+        if (DBKeuze == 1) {
+            try {
+                cpds = new ComboPooledDataSource();
+
+                cpds.setDriverClass(MYSQL_DRIVER_CLASS);
+                cpds.setJdbcUrl(MYSQL_URL);
+                cpds.setUser(MYSQL_USER);
+                cpds.setPassword(MYSQL_PASSWORD);
+
+            } catch (PropertyVetoException ex) {
+                throw new RSVIERException("PropertyVetoExcepton in C3PO connection pool");
+            }
+        }
+    }
+
+    public static connection_pools.c3poDataSource getInstance(int DBKeuze) throws RSVIERException {
+        if (c3poDataSource == null) {
+            c3poDataSource = new c3poDataSource(DBKeuze);
+            return c3poDataSource;
+        } else {
+            return c3poDataSource;
+        }
+    }
+
+    public Connection getConnection() throws SQLException {
+        return this.cpds.getConnection();
+    }
+}

--- a/src/factories/ConnectionPoolFactory.java
+++ b/src/factories/ConnectionPoolFactory.java
@@ -1,0 +1,37 @@
+package factories;
+
+import com.mysql.jdbc.StringUtils;
+import connection_pools.C3POAdapter;
+import connection_pools.OudeMySQLConnectorAdapter;
+import exceptions.RSVIERException;
+import interfaces.VerkrijgConnectie;
+
+/**
+ * Created by Milan_Verheij on 19-06-16.
+ *
+ * Dit is de factory voor de juiste connection Pool. Er wordt door middel
+ * van een unieke waarde per type connectionpool de juiste factory gemaakt.
+ *
+ */
+
+public class ConnectionPoolFactory {
+    public static VerkrijgConnectie getConnectionPool(String connectionPoolKeuze, int DBKeuze) throws RSVIERException {
+        if (connectionPoolKeuze.length() > 1 || connectionPoolKeuze.length() == 0) {
+            throw new RSVIERException("ConnectionPoolFactory: U moet 1 karakter invullen als keuze");
+        } else
+        if (!StringUtils.isStrictlyNumeric(connectionPoolKeuze)) {
+            throw new RSVIERException("ConnectionPoolFactory: U moet een getal als keuze in vullen");
+        }
+
+        switch (connectionPoolKeuze.charAt(0)) {
+            case '1':
+                    return new C3POAdapter(DBKeuze);
+            case '2':
+                    throw new RSVIERException("ConnectionPoolFactory: JIKARICP NOG NIET GEIMPLEMENTEERD");
+            case '3':
+                    return new OudeMySQLConnectorAdapter();
+            default:
+                    throw new RSVIERException("ConnectionPoolFactory: VERKEERDE KEUZE VOOR CONNECTION POOL: " + connectionPoolKeuze);
+        }
+    }
+}

--- a/src/factories/ConnectionPoolFactory.java
+++ b/src/factories/ConnectionPoolFactory.java
@@ -2,6 +2,7 @@ package factories;
 
 import com.mysql.jdbc.StringUtils;
 import connection_pools.C3POAdapter;
+import connection_pools.HikariCPAdapter;
 import connection_pools.OudeMySQLConnectorAdapter;
 import exceptions.RSVIERException;
 import interfaces.VerkrijgConnectie;
@@ -17,21 +18,24 @@ import interfaces.VerkrijgConnectie;
 public class ConnectionPoolFactory {
     public static VerkrijgConnectie getConnectionPool(String connectionPoolKeuze, int DBKeuze) throws RSVIERException {
         if (connectionPoolKeuze.length() > 1 || connectionPoolKeuze.length() == 0) {
-            throw new RSVIERException("ConnectionPoolFactory: U moet 1 karakter invullen als keuze");
+            throw new RSVIERException("ConnectionPoolFactory: U moet 1 karakter invullen als keuze" +
+                    "\nKeuzes: 1: C3PO, 2: HikariCP, 3: MySQLConnectieLeverancier");
         } else
         if (!StringUtils.isStrictlyNumeric(connectionPoolKeuze)) {
-            throw new RSVIERException("ConnectionPoolFactory: U moet een getal als keuze in vullen");
+            throw new RSVIERException("ConnectionPoolFactory: U moet een getal als keuze in vullen" +
+                    "\nKeuzes: 1: C3PO, 2: HikariCP, 3: MySQLConnectieLeverancier");
         }
 
         switch (connectionPoolKeuze.charAt(0)) {
             case '1':
                     return new C3POAdapter(DBKeuze);
             case '2':
-                    throw new RSVIERException("ConnectionPoolFactory: JIKARICP NOG NIET GEIMPLEMENTEERD");
+                    return new HikariCPAdapter(DBKeuze);
             case '3':
                     return new OudeMySQLConnectorAdapter();
             default:
-                    throw new RSVIERException("ConnectionPoolFactory: VERKEERDE KEUZE VOOR CONNECTION POOL: " + connectionPoolKeuze);
+                    throw new RSVIERException("ConnectionPoolFactory: VERKEERDE KEUZE VOOR CONNECTION POOL: " + connectionPoolKeuze +
+                            "\nKeuzes: 1: C3PO, 2: HikariCP, 3: MySQLConnectieLeverancier");
         }
     }
 }

--- a/src/factories/ConnectionPoolFactory.java
+++ b/src/factories/ConnectionPoolFactory.java
@@ -16,6 +16,17 @@ import interfaces.VerkrijgConnectie;
  */
 
 public class ConnectionPoolFactory {
+
+    /**
+     * Geeft op basis van de gekozen Database Soort (1 = MySQL, 2 = FireBird) en
+     * gekozen Connection Pool (1 = C3PO, 2 = HikariCP, 3 = MySQlConnectieLeverancier)
+     * de juiste Connection Pool Adapter terug.
+     *
+     * @param connectionPoolKeuze Keuze voor de connection pool (zie keuzes hierboven).
+     * @param DBKeuze Keuze voor type database (zie keuzes hierboven).
+     * @return Adapter behorend bij bovenstaande keuzes.
+     * @throws RSVIERException Foutmelding met omschrijving.
+     */
     public static VerkrijgConnectie getConnectionPool(String connectionPoolKeuze, int DBKeuze) throws RSVIERException {
         if (connectionPoolKeuze.length() > 1 || connectionPoolKeuze.length() == 0) {
             throw new RSVIERException("ConnectionPoolFactory: U moet 1 karakter invullen als keuze" +

--- a/src/factories/DAOFactory.java
+++ b/src/factories/DAOFactory.java
@@ -1,5 +1,8 @@
 package factories;
 
+import exceptions.RSVIERException;
+import interfaces.VerkrijgConnectie;
+
 /**
  * @author Milan_Verheij
  * <p>
@@ -30,9 +33,9 @@ public abstract class DAOFactory {
 	 *
 	 * @return Een KlantDAO van het eerder gekozen database-type.
      */
-	public abstract interfaces.KlantDAO getKlantDAO();
+	public abstract interfaces.KlantDAO getKlantDAO(String connPoolKeuze) throws RSVIERException;
 
-	public abstract interfaces.AdresDAO getAdresDAO();
+	public abstract interfaces.AdresDAO getAdresDAO(String connPoolKeuze) throws RSVIERException;
 
 	/**
 	 * De methode die geimplementeerd dient te worden door de concrete fabriek

--- a/src/factories/DAOFactory.java
+++ b/src/factories/DAOFactory.java
@@ -34,6 +34,12 @@ public abstract class DAOFactory {
      */
 	public abstract interfaces.KlantDAO getKlantDAO(String connPoolKeuze) throws RSVIERException;
 
+	/**
+	 * De methode die geimplementeerd dient te worden door de concrete fabriek
+	 * om een AdresDAO te maken.
+	 *
+	 * @return Een AdresDAO van het eerder gekozen database-type.
+	 */
 	public abstract interfaces.AdresDAO getAdresDAO(String connPoolKeuze) throws RSVIERException;
 
 	/**
@@ -43,6 +49,13 @@ public abstract class DAOFactory {
 	 * @return Een BestellingDAO van het eerder gekozen database-type.
      */
 	public abstract interfaces.BestellingDAO getBestellingDAO();
+
+	/**
+	 * De methode die geimplementeerd dient te worden door de concrete fabriek
+	 * om een ArtikelDAO te maken.
+	 *
+	 * @return Een ArtikelDAO van het eerder gekozen database-type.
+	 */
 	public abstract interfaces.ArtikelDAO getArtikelDAO();
 	
 	

--- a/src/factories/DAOFactory.java
+++ b/src/factories/DAOFactory.java
@@ -1,7 +1,6 @@
 package factories;
 
 import exceptions.RSVIERException;
-import interfaces.VerkrijgConnectie;
 
 /**
  * @author Milan_Verheij
@@ -18,8 +17,8 @@ public abstract class DAOFactory {
 	 * @param s De keuze van het databasetype in String formaat.
 	 * @return Geeft een concrete DAO fabriek terug.
      */
-	public static DAOFactory getDAOFactory(String s){
-		if(s.equals("MySQL")) 
+	public static DAOFactory getDAOFactory(String s) {
+		if(s.equals("MySQL"))
 			return new DAOFactoryMySQL();
 //		else if(s.equals("FireBird"))
 //			return new FireBirdDAOFactory();

--- a/src/factories/DAOFactory.java
+++ b/src/factories/DAOFactory.java
@@ -20,8 +20,8 @@ public abstract class DAOFactory {
 	public static DAOFactory getDAOFactory(String s) {
 		if(s.equals("MySQL"))
 			return new DAOFactoryMySQL();
-//		else if(s.equals("FireBird"))
-//			return new FireBirdDAOFactory();
+		else if(s.equals("FireBird"))
+			return new DAOFactoryFireBird();
 		else
 			return null;
 	}
@@ -48,7 +48,7 @@ public abstract class DAOFactory {
 	 *
 	 * @return Een BestellingDAO van het eerder gekozen database-type.
      */
-	public abstract interfaces.BestellingDAO getBestellingDAO();
+	public abstract interfaces.BestellingDAO getBestellingDAO(String connPoolKeuze) throws RSVIERException;
 
 	/**
 	 * De methode die geimplementeerd dient te worden door de concrete fabriek
@@ -56,7 +56,7 @@ public abstract class DAOFactory {
 	 *
 	 * @return Een ArtikelDAO van het eerder gekozen database-type.
 	 */
-	public abstract interfaces.ArtikelDAO getArtikelDAO();
+	public abstract interfaces.ArtikelDAO getArtikelDAO(String connPoolKeuze) throws RSVIERException;
 	
 	
 }

--- a/src/factories/DAOFactoryFireBird.java
+++ b/src/factories/DAOFactoryFireBird.java
@@ -1,0 +1,73 @@
+package factories;
+
+import exceptions.RSVIERException;
+import firebird.AbstractDAOFireBird;
+import interfaces.AdresDAO;
+import interfaces.ArtikelDAO;
+import interfaces.BestellingDAO;
+import interfaces.KlantDAO;
+
+/**
+ * @author Milan_Verheij
+ * <p>
+ * Deze concrete factory van het type FireBird maakt DAO's
+ * aan voor de database FireBird(DBKeuze 2) en geeft deze terug aan de gebruiker.
+ *
+ * Stelt daarnaast de AbstractDAOFireBird in op de gekozen Connection Pool.
+ */
+
+public class DAOFactoryFireBird extends DAOFactory{
+
+	/**
+	 * Methode om de een KlantDAO te maken.
+	 * Stelt daarnaast de AbstractDAOFireBird in op de gekozen Connection Pool.
+	 *
+	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
+	 * @return een KlantDAO van het FireBird-type(DBKeuze 2).
+     */
+	@Override
+	public KlantDAO getKlantDAO(String connPoolKeuze) throws RSVIERException {
+		AbstractDAOFireBird.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 2));
+		return null;
+	}
+
+	/**
+	 * Methode om de een AdresDAO te maken.
+	 * Stelt daarnaast de AbstractDAOFireBird in op de gekozen Connection Pool.
+	 *
+	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
+	 * @return een AdresDAO van het FireBird-type(DBKeuze 2).
+     */
+	@Override
+	public AdresDAO getAdresDAO(String connPoolKeuze) throws RSVIERException {
+		AbstractDAOFireBird.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 2));
+		return null;
+	}
+
+	/**
+	 * Methode om de een BestellingDAO te maken.
+	 * Stelt daarnaast de AbstractDAOFireBird in op de gekozen Connection Pool.
+	 *
+	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
+	 * @return een BestellingDAO van het FireBird-type(DBKeuze 2).
+	 */
+	@Override
+	public BestellingDAO getBestellingDAO(String connPoolKeuze) throws RSVIERException {
+		AbstractDAOFireBird.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 2));
+		return null;
+	}
+
+	/**
+	 * Methode om de een ArtikelDAO te maken.
+	 * Stelt daarnaast de AbstractDAOFireBird in op de gekozen Connection Pool.
+	 *
+	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
+	 * @return een ArtikelDAO van het FireBird-type(DBKeuze 2).
+	 */
+	@Override
+	public ArtikelDAO getArtikelDAO(String connPoolKeuze) throws RSVIERException {
+		AbstractDAOFireBird.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 2));
+		return null;
+	}
+
+}

--- a/src/factories/DAOFactoryMySQL.java
+++ b/src/factories/DAOFactoryMySQL.java
@@ -2,6 +2,9 @@ package factories;
 
 import exceptions.RSVIERException;
 import interfaces.*;
+import mysql.AbstractDAOMySQL;
+import mysql.AdresDAOMySQL;
+import mysql.KlantDAOMySQL;
 
 /**
  * @author Milan_Verheij
@@ -19,7 +22,8 @@ public class DAOFactoryMySQL extends DAOFactory{
      */
 	@Override
 	public KlantDAO getKlantDAO(String connPoolKeuze) throws RSVIERException {
-		return new mysql.KlantDAOMySQL(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
+		AbstractDAOMySQL.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
+		return new KlantDAOMySQL();
 	}
 
 	/**
@@ -29,7 +33,8 @@ public class DAOFactoryMySQL extends DAOFactory{
      */
 	@Override
 	public AdresDAO getAdresDAO(String connPoolKeuze) throws RSVIERException {
-		return new mysql.AdresDAOMySQL(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
+		AbstractDAOMySQL.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
+		return new AdresDAOMySQL();
 	}
 
 	/**

--- a/src/factories/DAOFactoryMySQL.java
+++ b/src/factories/DAOFactoryMySQL.java
@@ -1,9 +1,7 @@
 package factories;
 
-import interfaces.AdresDAO;
-import interfaces.ArtikelDAO;
-import interfaces.BestellingDAO;
-import interfaces.KlantDAO;
+import exceptions.RSVIERException;
+import interfaces.*;
 
 /**
  * @author Milan_Verheij
@@ -20,8 +18,8 @@ public class DAOFactoryMySQL extends DAOFactory{
 	 * @return een KlantDAO van het MySQL-type
      */
 	@Override
-	public KlantDAO getKlantDAO() {
-		return new mysql.KlantDAOMySQL();
+	public KlantDAO getKlantDAO(String connPoolKeuze) throws RSVIERException {
+		return new mysql.KlantDAOMySQL(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
 	}
 
 	/**
@@ -30,8 +28,8 @@ public class DAOFactoryMySQL extends DAOFactory{
 	 * @return een AdresDAO van het MySQL-type
      */
 	@Override
-	public AdresDAO getAdresDAO() {
-		return new mysql.AdresDAOMySQL();
+	public AdresDAO getAdresDAO(String connPoolKeuze) throws RSVIERException {
+		return new mysql.AdresDAOMySQL(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
 	}
 
 	/**

--- a/src/factories/DAOFactoryMySQL.java
+++ b/src/factories/DAOFactoryMySQL.java
@@ -11,13 +11,17 @@ import mysql.KlantDAOMySQL;
  * <p>
  * Deze concrete factory van het type MySQL maakt DAO's
  * aan voor de database MySQL en geeft deze terug aan de gebruiker.
+ *
+ * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
  */
 
 public class DAOFactoryMySQL extends DAOFactory{
 
 	/**
 	 * Methode om de een KlantDAO te maken.
+	 * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
 	 *
+	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
 	 * @return een KlantDAO van het MySQL-type
      */
 	@Override
@@ -28,7 +32,9 @@ public class DAOFactoryMySQL extends DAOFactory{
 
 	/**
 	 * Methode om de een AdresDAO te maken.
+	 * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
 	 *
+	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
 	 * @return een AdresDAO van het MySQL-type
      */
 	@Override

--- a/src/factories/DAOFactoryMySQL.java
+++ b/src/factories/DAOFactoryMySQL.java
@@ -2,9 +2,7 @@ package factories;
 
 import exceptions.RSVIERException;
 import interfaces.*;
-import mysql.AbstractDAOMySQL;
-import mysql.AdresDAOMySQL;
-import mysql.KlantDAOMySQL;
+import mysql.*;
 
 /**
  * @author Milan_Verheij
@@ -22,7 +20,7 @@ public class DAOFactoryMySQL extends DAOFactory{
 	 * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
 	 *
 	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
-	 * @return een KlantDAO van het MySQL-type
+	 * @return een KlantDAO van het MySQL-type(DBKeuze 1).
      */
 	@Override
 	public KlantDAO getKlantDAO(String connPoolKeuze) throws RSVIERException {
@@ -35,7 +33,7 @@ public class DAOFactoryMySQL extends DAOFactory{
 	 * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
 	 *
 	 * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
-	 * @return een AdresDAO van het MySQL-type
+	 * @return een AdresDAO van het MySQL-type(DBKeuze 1).
      */
 	@Override
 	public AdresDAO getAdresDAO(String connPoolKeuze) throws RSVIERException {
@@ -43,23 +41,30 @@ public class DAOFactoryMySQL extends DAOFactory{
 		return new AdresDAOMySQL();
 	}
 
-	/**
-	 * Methode om een BestellingDAO te maken.
-	 *
-	 * @return een BestellingDAO van het MySQL-type.
+    /**
+     * Methode om de een BestellingDAO te maken.
+     * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
+     *
+     * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
+     * @return een BestellingDAO van het MySQL-type(DBKeuze 1).
      */
 	@Override
-	public BestellingDAO getBestellingDAO() {
-		return new mysql.BestellingDAOMySQL();
+	public BestellingDAO getBestellingDAO(String connPoolKeuze) throws RSVIERException {
+		AbstractDAOMySQL.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
+		return new BestellingDAOMySQL();
 	}
 
-	/**
-	 * Methode om een ArtikelDAO te maken;
-	 * @return een ArtikelDAO van het MySQL-type
+    /**
+     * Methode om de een ArtikelDAO te maken.
+     * Stelt daarnaast de AbstractDAOMySQL in op de gekozen Connection Pool.
+     *
+     * @param connPoolKeuze Keuze voor het type connectionPool, zie ConnectionPoolFactory.
+     * @return een ArtikelDAO van het MySQL-type(DBKeuze 1).
      */
 	@Override
-	public ArtikelDAO getArtikelDAO() {
-		return new mysql.ArtikelDAOMySQL();
+	public ArtikelDAO getArtikelDAO(String connPoolKeuze) throws RSVIERException {
+		AbstractDAOMySQL.setConnPool(ConnectionPoolFactory.getConnectionPool(connPoolKeuze, 1));
+		return new ArtikelDAOMySQL();
 	}
 
 }

--- a/src/firebird/AbstractDAOFireBird.java
+++ b/src/firebird/AbstractDAOFireBird.java
@@ -1,0 +1,14 @@
+package firebird;
+
+import interfaces.VerkrijgConnectie;
+
+import java.sql.PreparedStatement;
+
+public abstract class AbstractDAOFireBird {
+	PreparedStatement statement;
+	static VerkrijgConnectie connPool;
+
+	public static void setConnPool(VerkrijgConnectie connPool) {
+		AbstractDAOFireBird.connPool = connPool;
+	}
+}

--- a/src/interfaces/VerkrijgConnectie.java
+++ b/src/interfaces/VerkrijgConnectie.java
@@ -8,8 +8,18 @@ import java.sql.Connection;
  * Created by Milan_Verheij on 19-06-16.
  *
  * Interface voor generieke verkrijging van een connectie afhankelijk van
- * connectie pool.
+ * connectie pool. Wordt geimplementeerd door de diverse ConnectionPool
+ * Adapters. Zie verder deze Adapters in de connection_pools package.
+ *
  */
 public interface VerkrijgConnectie {
+
+    /**
+     * Retourneert een Connection object aangeleverd door een van de
+     * connection pools welke deze interface implementeren.
+     *
+     * @return Een connection object van een van de connection pools.
+     * @throws RSVIERException Gooit een fout terug met de bijbehorende message.
+     */
    Connection verkrijgConnectie() throws RSVIERException ;
 }

--- a/src/interfaces/VerkrijgConnectie.java
+++ b/src/interfaces/VerkrijgConnectie.java
@@ -1,0 +1,15 @@
+package interfaces;
+
+import exceptions.RSVIERException;
+
+import java.sql.Connection;
+
+/**
+ * Created by Milan_Verheij on 19-06-16.
+ *
+ * Interface voor generieke verkrijging van een connectie afhankelijk van
+ * connectie pool.
+ */
+public interface VerkrijgConnectie {
+   Connection verkrijgConnectie() throws RSVIERException ;
+}

--- a/src/mysql/AbstractDAOMySQL.java
+++ b/src/mysql/AbstractDAOMySQL.java
@@ -1,9 +1,10 @@
 package mysql;
 
+import connection_pools.C3POAdapter;
+import interfaces.VerkrijgConnectie;
+
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 public class AbstractDAOMySQL {
 	PreparedStatement statement;
-	ResultSet resultSet;
 }

--- a/src/mysql/AbstractDAOMySQL.java
+++ b/src/mysql/AbstractDAOMySQL.java
@@ -1,10 +1,14 @@
 package mysql;
 
-import connection_pools.C3POAdapter;
 import interfaces.VerkrijgConnectie;
 
 import java.sql.PreparedStatement;
 
-public class AbstractDAOMySQL {
+public abstract class AbstractDAOMySQL {
 	PreparedStatement statement;
+	static VerkrijgConnectie connPool;
+
+	public static void setConnPool(VerkrijgConnectie connPool) {
+		AbstractDAOMySQL.connPool = connPool;
+	}
 }

--- a/src/mysql/AdresDAOMySQL.java
+++ b/src/mysql/AdresDAOMySQL.java
@@ -2,7 +2,6 @@ package mysql;
 
 import exceptions.RSVIERException;
 import interfaces.AdresDAO;
-import interfaces.VerkrijgConnectie;
 import model.Adres;
 
 import java.sql.*;
@@ -24,12 +23,8 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
     public static boolean klantWordtGetest = false;
     public static Adres aangeroepenAdresInTest = new Adres("XXXXXX", "XXXX", "XX", 0000, "XXXX"); // Geeft altijd FOUT
     private ArrayList<Adres> adresLijst;
-    VerkrijgConnectie connPool;
 
 
-    public AdresDAOMySQL(VerkrijgConnectie connPoolAdapter) {
-        this.connPool = connPoolAdapter;
-    }
     /**
      * Update een adres bij een klant op basis van een Adres-object en adres_id.
      *

--- a/src/mysql/AdresDAOMySQL.java
+++ b/src/mysql/AdresDAOMySQL.java
@@ -2,6 +2,7 @@ package mysql;
 
 import exceptions.RSVIERException;
 import interfaces.AdresDAO;
+import interfaces.VerkrijgConnectie;
 import model.Adres;
 
 import java.sql.*;
@@ -23,7 +24,12 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
     public static boolean klantWordtGetest = false;
     public static Adres aangeroepenAdresInTest = new Adres("XXXXXX", "XXXX", "XX", 0000, "XXXX"); // Geeft altijd FOUT
     private ArrayList<Adres> adresLijst;
+    VerkrijgConnectie connPool;
 
+
+    public AdresDAOMySQL(VerkrijgConnectie connPoolAdapter) {
+        this.connPool = connPoolAdapter;
+    }
     /**
      * Update een adres bij een klant op basis van een Adres-object en adres_id.
      *
@@ -55,7 +61,7 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
                 "WHERE adres_id = ?;";
 
         try (
-                Connection connection = MySQLConnectieLeverancier.getConnection();
+                Connection connection = connPool.verkrijgConnectie();
                 PreparedStatement statement= connection.prepareStatement(query)
         ) {
             statement.setString(1, adresgegevens.getStraatnaam());
@@ -88,7 +94,7 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
                 "(?,              ?);";
 
         try (
-                Connection connection = MySQLConnectieLeverancier.getConnection();
+                Connection connection = connPool.verkrijgConnectie();
                 PreparedStatement statement = connection.prepareStatement(query);
         )
         {
@@ -127,7 +133,7 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
                 "(?,        ?);";
 
         try (
-                Connection connection = MySQLConnectieLeverancier.getConnection();
+                Connection connection = connPool.verkrijgConnectie();
                 PreparedStatement statementNieuwAdres = connection.prepareStatement(queryNieuwAdres, Statement.RETURN_GENERATED_KEYS);
                 PreparedStatement statementAdresKlantKoppeling = connection.prepareStatement(queryAdresKlantKoppeling);
         )
@@ -186,7 +192,7 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
                 "toevoeging = ?;";
 
         try (
-                Connection connection = MySQLConnectieLeverancier.getConnection();
+                Connection connection = connPool.verkrijgConnectie();
                 PreparedStatement statement = connection.prepareStatement(query);
         ) {
             statement.setString(1, postcode);
@@ -226,7 +232,7 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
                 "KLANT_HEEFT_ADRES.klant_id_klant = ?;";
 
         try (
-                Connection connection = MySQLConnectieLeverancier.getConnection();
+                Connection connection = connPool.verkrijgConnectie();
                 PreparedStatement statement = connection.prepareStatement(query);
         ) {
             statement.setLong(1, klant_id);
@@ -281,7 +287,7 @@ public class AdresDAOMySQL extends AbstractDAOMySQL implements AdresDAO {
                         "adres_id = ?";
 
         try (
-                Connection connection = MySQLConnectieLeverancier.getConnection();
+                Connection connection = connPool.verkrijgConnectie();
                 PreparedStatement statement = connection.prepareStatement(query)
         ) {
             statement.setInt(1, status);

--- a/src/mysql/KlantDAOMySQL.java
+++ b/src/mysql/KlantDAOMySQL.java
@@ -3,7 +3,6 @@ package mysql;
 import com.mysql.jdbc.Statement;
 import exceptions.RSVIERException;
 import interfaces.KlantDAO;
-import interfaces.VerkrijgConnectie;
 import model.Adres;
 import model.Bestelling;
 import model.Klant;
@@ -33,11 +32,10 @@ public class KlantDAOMySQL extends AbstractDAOMySQL implements KlantDAO {
     ArrayList<Klant> klantenLijst;
     BestellingDAOMySQL bestellingDAO;
     AdresDAOMySQL adresDAO;
-    VerkrijgConnectie connPool;
 
-    public KlantDAOMySQL(VerkrijgConnectie connPoolAdapter) {
-        this.connPool = connPoolAdapter;
-    }
+//    public KlantDAOMySQL(VerkrijgConnectie connPoolAdapter) {
+//        this.connPool = connPoolAdapter;
+//    }
 
     /** CREATE METHODS */
 
@@ -94,20 +92,20 @@ public class KlantDAOMySQL extends AbstractDAOMySQL implements KlantDAO {
                 // Als er een adres_id wordt meegegeven betekent dit dat er een bestaand adres gekoppeled wordt
                 // aan een nieuwe klant
                 if (adres_id > 0 && adresgegevens == null) {
-                    adresDAO = new AdresDAOMySQL(connPool);
+                    adresDAO = new AdresDAOMySQL();
                     adresDAO.koppelAdresAanKlant(nieuwId, adres_id);
                 }
 
                 // Als er adresgegeven worden meegegeven wordt er een adres aangemaakt op basis van het nieuwe klantId
                 else if (adresgegevens != null && adres_id == 0) {
-                    adresDAO = new AdresDAOMySQL(connPool);
+                    adresDAO = new AdresDAOMySQL();
                     adresDAO.nieuwAdres(nieuwId, adresgegevens);
                 }
 
                 // Als er adresgegeven worden meegegeven en een adres_id wordt er zowel een nieuw adres aangemaakt
                 // en tevens het bestaande adres gekoppeld.
                 else if (adresgegevens != null && adres_id > 0) {
-                    adresDAO = new AdresDAOMySQL(connPool);
+                    adresDAO = new AdresDAOMySQL();
                     adresDAO.nieuwAdres(nieuwId, adresgegevens);
                     adresDAO.koppelAdresAanKlant(nieuwId, adres_id);
                 }
@@ -522,7 +520,7 @@ public class KlantDAOMySQL extends AbstractDAOMySQL implements KlantDAO {
                             long adres_id,
                             Adres adresgegevens) throws RSVIERException {
         updateKlant(KlantId, voornaam, achternaam, tussenvoegsel, email);
-        adresDAO = new AdresDAOMySQL(connPool);
+        adresDAO = new AdresDAOMySQL();
         adresDAO.updateAdres(adres_id, adresgegevens);
     }
 
@@ -690,7 +688,7 @@ public class KlantDAOMySQL extends AbstractDAOMySQL implements KlantDAO {
                 System.out.print("\n\t----------");
 
                 // DAO voor adres-acties. Lijst verkrijgen van alle adressen bijbehorend bij klant_id
-                adresDAO = new AdresDAOMySQL(connPool);
+                adresDAO = new AdresDAOMySQL();
                 ListIterator<Adres> adresListIterator = adresDAO.getAdresOpKlantID(tijdelijkeKlant.getKlant_id());
                 while (adresListIterator.hasNext()) {
 

--- a/src/mysql/MySQLConnectieLeverancier.java
+++ b/src/mysql/MySQLConnectieLeverancier.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
  *
  */
 
+@Deprecated
 public class MySQLConnectieLeverancier {
     // Instant van deze klasse. De enige instance die er zal zijn.
     @SuppressWarnings("unused")
@@ -37,6 +38,7 @@ public class MySQLConnectieLeverancier {
      *
      *  Geen parameters
      */
+    @Deprecated
     private MySQLConnectieLeverancier() {
         try {
             // Laden van de mysql Driver en log in console als dit gelukt is
@@ -55,6 +57,7 @@ public class MySQLConnectieLeverancier {
      *
      * @return De gemaakte connectie met de database.
      */
+    @Deprecated
     private synchronized static Connection connectToDatabase() throws RSVIERException {
         try {
             connection = DriverManager.getConnection(URL, USER, PASSWORD);
@@ -70,6 +73,7 @@ public class MySQLConnectieLeverancier {
      *
      * @return de connectie gemaakt in de methode connecToDatabase
      */
+    @Deprecated
     public static Connection getConnection() throws RSVIERException {
         return connectToDatabase();
     }
@@ -78,6 +82,7 @@ public class MySQLConnectieLeverancier {
      * Methode om de logModus van de connector aan en uit te zetten
      * @param logModus Logmodus uit (0) of logModus aan (1).
      */
+    @Deprecated
     public static void setLogModus(int logModus) {
         MySQLConnectieLeverancier.logModus = logModus;
     }

--- a/src/mysql/MySQLHelper.java
+++ b/src/mysql/MySQLHelper.java
@@ -25,6 +25,7 @@ public class MySQLHelper {
      *
      * @param connection Meegegeven connectie om te sluiten
      */
+    @Deprecated
     public static void close(Connection connection, PreparedStatement preparedStatement, ResultSet resultSet) {
         close(resultSet);
         close(preparedStatement);
@@ -39,6 +40,7 @@ public class MySQLHelper {
      * @param preparedStatement Meegegeven statement om te sluiten
      * @param connection Meegegeven connectie om te sluiten
      */
+    @Deprecated
     public static void close(Connection connection, PreparedStatement preparedStatement) {
         close(preparedStatement);
         close(connection);
@@ -52,6 +54,7 @@ public class MySQLHelper {
      * @param preparedStatement Meegegeven statement om te sluiten
      * @param resultSet Meegegeven resultset om te sluiten
      */
+    @Deprecated
     public static void close(PreparedStatement preparedStatement, ResultSet resultSet) {
         close(resultSet);
         close(preparedStatement);
@@ -61,6 +64,7 @@ public class MySQLHelper {
      * Als er een connectie is wordt deze gesloten.
      * @param connection Meegegeven connectie om te sluiten
      */
+    @Deprecated
     public static void close(Connection connection) {
         if (connection != null) {
             try {
@@ -78,6 +82,7 @@ public class MySQLHelper {
      * Als er een PreparedStatement is wordt deze gesloten
      * @param statement Meegegeven statement om te sluiten
      */
+    @Deprecated
     public static void close(PreparedStatement statement) {
         if (statement != null) {
             try {
@@ -94,6 +99,7 @@ public class MySQLHelper {
      * Als er een resultSet is wordt deze gesloten
      * @param resultSet Meegegeven resultset om te sluiten
      */
+    @Deprecated
     public static void close(ResultSet resultSet) {
         if (resultSet != null) {
             try {
@@ -110,6 +116,7 @@ public class MySQLHelper {
      * Als er een rowSet is wordt deze gesloten.
      * @param rowSet Meegegeven rowSet om te sluiten
      */
+    @Deprecated
     public static void close(RowSet rowSet) {
         if (rowSet != null) {
             try {
@@ -126,6 +133,7 @@ public class MySQLHelper {
      *
      * @param logModus: Logmodus uit(0) of aan(1)
      */
+    @Deprecated
     public static void setLogModus(int logModus) {
         MySQLHelper.logModus = logModus;
     }


### PR DESCRIPTION
Connection Pools toegevoegd door middel van een eigen Factory.

Bij het maken van een DAO (.get[type]DAO) wordt een keuze voor connection_pool meegegeven (1, 2, 3, zie doc). 

In de abstractDAO's wordt een algemene connectionpool ingesteld welke elke DAO kan gebruiken, de connection pool regelt de rest. Dit doet de specifieke DatabaseDAO, deze stelt de connection pool dus goed in.

Verder is FireBird voorbereid zodat de bijbehorende DAO's gemaakt kunnen worden (factory returnt nu null).

Voor de diverse connection pools zijn adapters gemaakt welke de VerkrijgConnectie interface implementeren. Hierdoor heeft elke DAO dmv de gedeelde VerkrijgConnectie interface een generieke methode om aan een connection te komen.

